### PR TITLE
refactor: split UI and state into classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
               stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
 </svg>
-<script src="src/editor.js"></script>
+<script type="module" src="src/editor.js"></script>
 </body>
 
 </html>

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,88 +1,20 @@
-    (() => {
+import EditorUI from './ui.js';
+import EditorState from './state.js';
+
+(() => {
         const toolbar = document.getElementById('toolbar');
         const stageWrap = document.getElementById('stageWrap');
         const canvas = document.getElementById('canvas');
         const ctx = canvas.getContext('2d');
         const DPR = Math.max(1, window.devicePixelRatio || 1);
-        const UI = {
-            // tools
-            shapeMenu: document.getElementById('shapeMenu'),
-            shapeMenuBtn: document.getElementById('shapeMenuBtn'),
-            shapePop: document.getElementById('shapePop'),
-            // draw props
-            strokeWidth: document.getElementById('strokeWidth'),
-            strokeColor: document.getElementById('strokeColor'),
-            fillWrap: document.getElementById('fillWrap'),
-            fillColor: document.getElementById('fillColor'),
-            rotDeg: document.getElementById('rotDeg'),
-            // history / file
-            undo: document.getElementById('undo'),
-            redo: document.getElementById('redo'),
-            fileInput: document.getElementById('fileInput'),
-            saveJSON: document.getElementById('saveJSON'),
-            saveJSONMin: document.getElementById('saveJSONMin'),
-            exportPNG: document.getElementById('exportPNG'),
-            clear: document.getElementById('clear'),
-            // sidebar
-            tabElems: document.getElementById('tabElems'),
-            tabAnims: document.getElementById('tabAnims'),
-            panelElems: document.getElementById('panelElems'),
-            panelAnims: document.getElementById('panelAnims'),
-            elemList: document.getElementById('elemList'),
-            toggleAll: document.getElementById('toggleAll'),
-            deleteSel: document.getElementById('deleteSel'),
-            groupBtn: document.getElementById('groupBtn'),
-            ungroupBtn: document.getElementById('ungroupBtn'),
-            // timeline (bottom)
-            timeline: document.getElementById('timeline'),
-            ticks: document.getElementById('ticks'),
-            cursor: document.getElementById('cursor'),
-            playhead: document.getElementById('playhead'),
-            tlAddKey: document.getElementById('tlAddKey'),
-            tlPlay: document.getElementById('tlPlay'),
-            // anim panel
-            animName: document.getElementById('animName'),
-            animDur: document.getElementById('animDur'),
-            animSelect: document.getElementById('animSelect'),
-            addAnim: document.getElementById('addAnim'),
-            renameAnim: document.getElementById('renameAnim'),
-            setKey: document.getElementById('setKey'),
-            play: document.getElementById('play'),
-            pause: document.getElementById('pause'),
-            delAnim: document.getElementById('delAnim'),
-            // selection visuals
-            ghost: document.getElementById('ghost'),
-            rotHandle: document.getElementById('rotHandle'),
-            // apply
-            apply: document.getElementById('apply'),
-            help: document.getElementById('help'),
-            fillEnabled: document.getElementById('fillEnabled'),
-            fillMode: document.getElementById('fillMode'),
-        };
+        const UI = new EditorUI();
         // ========= State =========
         /** @typedef {{x:number,y:number}} Pt */
         /** @typedef {{id:string, kind:'line', p1:Pt, p2:Pt, color:string, width:number, rot?:number, visible?:boolean, name?:string}} LineItem */
         /** @typedef {{id:string, kind:'quadratic', p1:Pt, p2:Pt, cp:Pt, color:string, width:number, rot?:number, visible?:boolean, name?:string}} QuadItem */
         /** @typedef {{id:string, kind:'shape', path:Pt[], color:string, width:number, fill?:string, rot?:number, visible?:boolean, name?:string, children?:string[]}} ShapeItem */
         /** @typedef {{id:string, name:string, duration:number, keyframes:Array<{t:number, snapshot:any}>}} Anim */
-        let state = {
-            tool: 'select',
-            items: /** @type {(LineItem|QuadItem|ShapeItem)[]} */ ([]),
-            selected: /** @type {Set<string>} */ (new Set()),
-            drawing: null, // temp drawing item
-            history: [],
-            future: [],
-            animations: /** @type {Anim[]} */ ([]),
-            currentAnimId: null,
-            tl: {
-                sec: 0,
-                playing: false,
-                startTime: 0
-            },
-        };
-        // ========= DOM refs =========
-        // اضافه کردن ref جدید برای دکمه راهنما
-        UI.helpBtn = document.getElementById('helpBtn');
+        let state = new EditorState();
         // ========= کلیدهای میانبر =========
         const shortcuts = {
             'h': () => UI.helpBtn.click(), // نمایش/پنهان راهنما

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,17 @@
+export default class EditorState {
+  constructor() {
+    this.tool = 'select';
+    this.items = [];
+    this.selected = new Set();
+    this.drawing = null;
+    this.history = [];
+    this.future = [];
+    this.animations = [];
+    this.currentAnimId = null;
+    this.tl = {
+      sec: 0,
+      playing: false,
+      startTime: 0
+    };
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,59 @@
+export default class EditorUI {
+  constructor() {
+    // tools
+    this.shapeMenu = document.getElementById('shapeMenu');
+    this.shapeMenuBtn = document.getElementById('shapeMenuBtn');
+    this.shapePop = document.getElementById('shapePop');
+    // draw props
+    this.strokeWidth = document.getElementById('strokeWidth');
+    this.strokeColor = document.getElementById('strokeColor');
+    this.fillWrap = document.getElementById('fillWrap');
+    this.fillColor = document.getElementById('fillColor');
+    this.rotDeg = document.getElementById('rotDeg');
+    // history / file
+    this.undo = document.getElementById('undo');
+    this.redo = document.getElementById('redo');
+    this.fileInput = document.getElementById('fileInput');
+    this.saveJSON = document.getElementById('saveJSON');
+    this.saveJSONMin = document.getElementById('saveJSONMin');
+    this.exportPNG = document.getElementById('exportPNG');
+    this.clear = document.getElementById('clear');
+    // sidebar
+    this.tabElems = document.getElementById('tabElems');
+    this.tabAnims = document.getElementById('tabAnims');
+    this.panelElems = document.getElementById('panelElems');
+    this.panelAnims = document.getElementById('panelAnims');
+    this.elemList = document.getElementById('elemList');
+    this.toggleAll = document.getElementById('toggleAll');
+    this.deleteSel = document.getElementById('deleteSel');
+    this.groupBtn = document.getElementById('groupBtn');
+    this.ungroupBtn = document.getElementById('ungroupBtn');
+    // timeline (bottom)
+    this.timeline = document.getElementById('timeline');
+    this.ticks = document.getElementById('ticks');
+    this.cursor = document.getElementById('cursor');
+    this.playhead = document.getElementById('playhead');
+    this.tlAddKey = document.getElementById('tlAddKey');
+    this.tlPlay = document.getElementById('tlPlay');
+    // anim panel
+    this.animName = document.getElementById('animName');
+    this.animDur = document.getElementById('animDur');
+    this.animSelect = document.getElementById('animSelect');
+    this.addAnim = document.getElementById('addAnim');
+    this.renameAnim = document.getElementById('renameAnim');
+    this.setKey = document.getElementById('setKey');
+    this.play = document.getElementById('play');
+    this.pause = document.getElementById('pause');
+    this.delAnim = document.getElementById('delAnim');
+    // selection visuals
+    this.ghost = document.getElementById('ghost');
+    this.rotHandle = document.getElementById('rotHandle');
+    // apply
+    this.apply = document.getElementById('apply');
+    this.help = document.getElementById('help');
+    this.fillEnabled = document.getElementById('fillEnabled');
+    this.fillMode = document.getElementById('fillMode');
+    // extra refs
+    this.helpBtn = document.getElementById('helpBtn');
+  }
+}


### PR DESCRIPTION
## Summary
- split DOM references into `EditorUI` class
- encapsulate editor state in `EditorState` class and import them in main script
- switch HTML entry to module script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45e624004832180fc6508b6a5f1ef