### PR TITLE
Restore ungroup functionality after module split

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1,7 +1,7 @@
 import EditorUI from '../ui.js';
 import EditorState from '../state.js';
 import { registerShortcuts } from './shortcuts.js';
-import { groupSelection } from './grouping.js';
+import { groupSelection, ungroupSelection } from './grouping.js';
 
 /**
  * High level editor controller.  The original project kept all logic
@@ -28,6 +28,11 @@ export default class Editor {
   /** Initialise editor services and register listeners. */
   init() {
     registerShortcuts(this);
+    // Wire up basic grouping buttons similar to the original
+    // implementation so the split modules still expose the
+    // expected behaviour.
+    this.ui.groupBtn?.addEventListener('click', () => this.groupSelection());
+    this.ui.ungroupBtn?.addEventListener('click', () => this.ungroupSelection());
   }
 
   /** Update current drawing tool. */
@@ -38,6 +43,11 @@ export default class Editor {
   /** Group the currently selected items. */
   groupSelection() {
     groupSelection(this.state);
+  }
+
+  /** Ungroup the currently selected groups. */
+  ungroupSelection() {
+    ungroupSelection(this.state);
   }
 }
 

--- a/src/editor/grouping.js
+++ b/src/editor/grouping.js
@@ -15,3 +15,21 @@ export function groupSelection(state) {
   state.selected = new Set([groupId]);
 }
 
+/**
+ * Ungroup currently selected group items.  This mirrors the basic
+ * behaviour from the original monolithic implementation where a
+ * group element could be removed to reveal its children without
+ * any additional geometry processing.
+ */
+export function ungroupSelection(state) {
+  const groups = Array.from(state.selected || [])
+    .map(id => state.items.find(it => it.id === id))
+    .filter(it => it && it.kind === 'group');
+  if (groups.length === 0) return;
+
+  for (const group of groups) {
+    state.items = state.items.filter(it => it.id !== group.id);
+    state.selected.delete(group.id);
+  }
+}
+

--- a/src/editor/shortcuts.js
+++ b/src/editor/shortcuts.js
@@ -6,6 +6,7 @@
 export function registerShortcuts(editor) {
   const shortcuts = {
     g: () => editor.groupSelection(),
+    u: () => editor.ungroupSelection(),
     s: () => editor.setTool('select'),
     m: () => editor.setTool('move')
   };


### PR DESCRIPTION
## Summary
- Add `ungroupSelection` helper and expose it through the Editor class
- Wire up group/ungroup buttons and keyboard shortcut for ungroup

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4641f866c8321bc59fea8132f3a9f