### PR TITLE
feat: wire canvas events and modular tools

### DIFF
--- a/src/actions/clear.js
+++ b/src/actions/clear.js
@@ -1,0 +1,4 @@
+export default function clear(state) {
+  state.items = [];
+  state.future = [];
+}

--- a/src/actions/redo.js
+++ b/src/actions/redo.js
@@ -1,0 +1,6 @@
+export default function redo(state) {
+  const item = state.future.pop();
+  if (item) {
+    state.items.push(item);
+  }
+}

--- a/src/actions/undo.js
+++ b/src/actions/undo.js
@@ -1,0 +1,6 @@
+export default function undo(state) {
+  const last = state.items.pop();
+  if (last) {
+    state.future.push(last);
+  }
+}

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2,6 +2,15 @@ import EditorUI from '../ui.js';
 import EditorState from '../state.js';
 import { registerShortcuts } from './shortcuts.js';
 import { groupSelection, ungroupSelection } from './grouping.js';
+import SelectTool from '../tools/SelectTool.js';
+import MoveTool from '../tools/MoveTool.js';
+import LineTool from '../tools/LineTool.js';
+import QuadraticTool from '../tools/QuadraticTool.js';
+import RectTool from '../tools/RectTool.js';
+import EllipseTool from '../tools/EllipseTool.js';
+import undo from '../actions/undo.js';
+import redo from '../actions/redo.js';
+import clear from '../actions/clear.js';
 
 /**
  * High level editor controller.  The original project kept all logic
@@ -23,21 +32,101 @@ export default class Editor {
 
     // currently selected drawing tool
     this.currentTool = 'select';
+    this.toolInstance = null;
   }
 
   /** Initialise editor services and register listeners. */
   init() {
     registerShortcuts(this);
+    this.resizeCanvas();
+    window.addEventListener('resize', () => this.resizeCanvas());
+
     // Wire up basic grouping buttons similar to the original
     // implementation so the split modules still expose the
     // expected behaviour.
     this.ui.groupBtn?.addEventListener('click', () => this.groupSelection());
     this.ui.ungroupBtn?.addEventListener('click', () => this.ungroupSelection());
+
+    // Tool buttons
+    this.ui.shapePop?.querySelectorAll('button[data-tool]').forEach(btn => {
+      btn.addEventListener('click', () => this.setTool(btn.dataset.tool));
+    });
+
+    // Canvas events
+    this.canvas.addEventListener('mousedown', e => this.onPointerDown(e));
+    this.canvas.addEventListener('mousemove', e => this.onPointerMove(e));
+    window.addEventListener('mouseup', e => this.onPointerUp(e));
+
+    // Action buttons
+    this.ui.undo?.addEventListener('click', () => { undo(this.state); this.redraw(); });
+    this.ui.redo?.addEventListener('click', () => { redo(this.state); this.redraw(); });
+    this.ui.clear?.addEventListener('click', () => { clear(this.state); this.redraw(); });
+
+    this.setTool('select');
   }
+
+  resizeCanvas() {
+    const rect = this.stageWrap.getBoundingClientRect();
+    this.canvas.width = rect.width;
+    this.canvas.height = rect.height;
+  }
+
+  onPointerDown(e) { this.toolInstance?.start(e); }
+  onPointerMove(e) { this.toolInstance?.move(e); }
+  onPointerUp(e) { this.toolInstance?.end(e); }
 
   /** Update current drawing tool. */
   setTool(tool) {
     this.currentTool = tool;
+    const map = {
+      select: SelectTool,
+      move: MoveTool,
+      line: LineTool,
+      quadratic: QuadraticTool,
+      rect: RectTool,
+      ellipse: EllipseTool
+    };
+    const ToolClass = map[tool] || SelectTool;
+    this.toolInstance = new ToolClass(this);
+  }
+
+  redraw(preview) {
+    const ctx = this.ctx;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    const drawItem = item => {
+      ctx.lineWidth = item.strokeWidth;
+      ctx.strokeStyle = item.strokeColor;
+      ctx.beginPath();
+      switch (item.type) {
+        case 'line':
+          ctx.moveTo(item.x1, item.y1);
+          ctx.lineTo(item.x2, item.y2);
+          break;
+        case 'rect':
+          ctx.rect(item.x, item.y, item.w, item.h);
+          break;
+        case 'ellipse':
+          ctx.ellipse(
+            item.x + item.w / 2,
+            item.y + item.h / 2,
+            Math.abs(item.w) / 2,
+            Math.abs(item.h) / 2,
+            0,
+            0,
+            Math.PI * 2
+          );
+          break;
+        case 'quadratic':
+          const cx = (item.x1 + item.x2) / 2;
+          const cy = item.y1;
+          ctx.moveTo(item.x1, item.y1);
+          ctx.quadraticCurveTo(cx, cy, item.x2, item.y2);
+          break;
+      }
+      ctx.stroke();
+    };
+    this.state.items.forEach(drawItem);
+    if (preview) drawItem(preview);
   }
 
   /** Group the currently selected items. */
@@ -50,4 +139,3 @@ export default class Editor {
     ungroupSelection(this.state);
   }
 }
-

--- a/src/tools/EllipseTool.js
+++ b/src/tools/EllipseTool.js
@@ -1,0 +1,43 @@
+export default class EllipseTool {
+  constructor(editor) {
+    this.editor = editor;
+    this.drawing = false;
+    this.startX = 0;
+    this.startY = 0;
+  }
+  start(e) {
+    const { offsetX, offsetY } = e;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.drawing = true;
+  }
+  move(e) {
+    if (!this.drawing) return;
+    const { offsetX, offsetY } = e;
+    const preview = {
+      type: 'ellipse',
+      x: Math.min(this.startX, offsetX),
+      y: Math.min(this.startY, offsetY),
+      w: Math.abs(offsetX - this.startX),
+      h: Math.abs(offsetY - this.startY),
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    };
+    this.editor.redraw(preview);
+  }
+  end(e) {
+    if (!this.drawing) return;
+    this.drawing = false;
+    const { offsetX, offsetY } = e;
+    this.editor.state.items.push({
+      type: 'ellipse',
+      x: Math.min(this.startX, offsetX),
+      y: Math.min(this.startY, offsetY),
+      w: Math.abs(offsetX - this.startX),
+      h: Math.abs(offsetY - this.startY),
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    });
+    this.editor.redraw();
+  }
+}

--- a/src/tools/LineTool.js
+++ b/src/tools/LineTool.js
@@ -1,0 +1,43 @@
+export default class LineTool {
+  constructor(editor) {
+    this.editor = editor;
+    this.drawing = false;
+    this.startX = 0;
+    this.startY = 0;
+  }
+  start(e) {
+    const { offsetX, offsetY } = e;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.drawing = true;
+  }
+  move(e) {
+    if (!this.drawing) return;
+    const { offsetX, offsetY } = e;
+    const preview = {
+      type: 'line',
+      x1: this.startX,
+      y1: this.startY,
+      x2: offsetX,
+      y2: offsetY,
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    };
+    this.editor.redraw(preview);
+  }
+  end(e) {
+    if (!this.drawing) return;
+    this.drawing = false;
+    const { offsetX, offsetY } = e;
+    this.editor.state.items.push({
+      type: 'line',
+      x1: this.startX,
+      y1: this.startY,
+      x2: offsetX,
+      y2: offsetY,
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    });
+    this.editor.redraw();
+  }
+}

--- a/src/tools/MoveTool.js
+++ b/src/tools/MoveTool.js
@@ -1,0 +1,8 @@
+export default class MoveTool {
+  constructor(editor) {
+    this.editor = editor;
+  }
+  start() {}
+  move() {}
+  end() {}
+}

--- a/src/tools/QuadraticTool.js
+++ b/src/tools/QuadraticTool.js
@@ -1,0 +1,43 @@
+export default class QuadraticTool {
+  constructor(editor) {
+    this.editor = editor;
+    this.drawing = false;
+    this.startX = 0;
+    this.startY = 0;
+  }
+  start(e) {
+    const { offsetX, offsetY } = e;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.drawing = true;
+  }
+  move(e) {
+    if (!this.drawing) return;
+    const { offsetX, offsetY } = e;
+    const preview = {
+      type: 'quadratic',
+      x1: this.startX,
+      y1: this.startY,
+      x2: offsetX,
+      y2: offsetY,
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    };
+    this.editor.redraw(preview);
+  }
+  end(e) {
+    if (!this.drawing) return;
+    this.drawing = false;
+    const { offsetX, offsetY } = e;
+    this.editor.state.items.push({
+      type: 'quadratic',
+      x1: this.startX,
+      y1: this.startY,
+      x2: offsetX,
+      y2: offsetY,
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    });
+    this.editor.redraw();
+  }
+}

--- a/src/tools/RectTool.js
+++ b/src/tools/RectTool.js
@@ -1,0 +1,43 @@
+export default class RectTool {
+  constructor(editor) {
+    this.editor = editor;
+    this.drawing = false;
+    this.startX = 0;
+    this.startY = 0;
+  }
+  start(e) {
+    const { offsetX, offsetY } = e;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.drawing = true;
+  }
+  move(e) {
+    if (!this.drawing) return;
+    const { offsetX, offsetY } = e;
+    const preview = {
+      type: 'rect',
+      x: Math.min(this.startX, offsetX),
+      y: Math.min(this.startY, offsetY),
+      w: Math.abs(offsetX - this.startX),
+      h: Math.abs(offsetY - this.startY),
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    };
+    this.editor.redraw(preview);
+  }
+  end(e) {
+    if (!this.drawing) return;
+    this.drawing = false;
+    const { offsetX, offsetY } = e;
+    this.editor.state.items.push({
+      type: 'rect',
+      x: Math.min(this.startX, offsetX),
+      y: Math.min(this.startY, offsetY),
+      w: Math.abs(offsetX - this.startX),
+      h: Math.abs(offsetY - this.startY),
+      strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
+      strokeColor: this.editor.ui.strokeColor.value
+    });
+    this.editor.redraw();
+  }
+}

--- a/src/tools/SelectTool.js
+++ b/src/tools/SelectTool.js
@@ -1,0 +1,8 @@
+export default class SelectTool {
+  constructor(editor) {
+    this.editor = editor;
+  }
+  start() {}
+  move() {}
+  end() {}
+}


### PR DESCRIPTION
## Summary
- split line, rectangle, ellipse, quadratic and other tools into dedicated modules
- add undo/redo/clear actions and register toolbar buttons
- wire up canvas events for drawing and state updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a465e309c483219b30645ebbc9e576