### PR TITLE
fix: enable tool menu, shortcuts and grid

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -47,9 +47,18 @@ export default class Editor {
     this.ui.groupBtn?.addEventListener('click', () => this.groupSelection());
     this.ui.ungroupBtn?.addEventListener('click', () => this.ungroupSelection());
 
-    // Tool buttons
+    // Shape menu toggle
+    this.ui.shapeMenuBtn?.addEventListener('click', () => {
+      const expanded = this.ui.shapeMenu?.getAttribute('aria-expanded') === 'true';
+      this.ui.shapeMenu?.setAttribute('aria-expanded', (!expanded).toString());
+    });
+
+    // Tool buttons inside the popup
     this.ui.shapePop?.querySelectorAll('button[data-tool]').forEach(btn => {
-      btn.addEventListener('click', () => this.setTool(btn.dataset.tool));
+      btn.addEventListener('click', () => {
+        this.setTool(btn.dataset.tool);
+        this.ui.shapeMenu?.setAttribute('aria-expanded', 'false');
+      });
     });
 
     // Canvas events
@@ -62,7 +71,8 @@ export default class Editor {
     this.ui.redo?.addEventListener('click', () => { redo(this.state); this.redraw(); });
     this.ui.clear?.addEventListener('click', () => { clear(this.state); this.redraw(); });
 
-    this.setTool('select');
+    // Default to line tool so drawing works out of the box
+    this.setTool('line');
   }
 
   resizeCanvas() {
@@ -78,6 +88,10 @@ export default class Editor {
   /** Update current drawing tool. */
   setTool(tool) {
     this.currentTool = tool;
+    // reflect active tool in the popup menu
+    this.ui.shapePop?.querySelectorAll('button[data-tool]').forEach(btn => {
+      btn.setAttribute('aria-pressed', btn.dataset.tool === tool);
+    });
     const map = {
       select: SelectTool,
       move: MoveTool,

--- a/src/editor/shortcuts.js
+++ b/src/editor/shortcuts.js
@@ -1,8 +1,12 @@
+import undo from '../actions/undo.js';
+import redo from '../actions/redo.js';
+
 /**
  * Registers a minimal set of keyboard shortcuts.  The editor instance
  * passed in is expected to expose methods such as `setTool` and
  * `groupSelection`.
  */
+
 export function registerShortcuts(editor) {
   const shortcuts = {
     g: () => editor.groupSelection(),
@@ -13,6 +17,26 @@ export function registerShortcuts(editor) {
 
   window.addEventListener('keydown', e => {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+    // handle Ctrl/Meta combos
+    if (e.ctrlKey || e.metaKey) {
+      switch (e.key.toLowerCase()) {
+        case 'z':
+          e.preventDefault();
+          if (e.shiftKey) {
+            redo(editor.state);
+          } else {
+            undo(editor.state);
+          }
+          editor.redraw();
+          return;
+        case 'g':
+          e.preventDefault();
+          if (e.shiftKey) editor.ungroupSelection(); else editor.groupSelection();
+          return;
+      }
+    }
+
     const key = e.key.toLowerCase();
     if (shortcuts[key]) {
       e.preventDefault();

--- a/styles/editor.css
+++ b/styles/editor.css
@@ -252,7 +252,12 @@
 
         .stage-wrap {
             position: relative;
-            overflow: hidden
+            overflow: hidden;
+            /* chessboard style background */
+            background-image:
+                    linear-gradient(0deg, var(--grid) 1px, transparent 1px),
+                    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+            background-size: 20px 20px
         }
 
         canvas {


### PR DESCRIPTION
## Summary
- toggle tool menu and default to line tool
- add keyboard shortcuts for undo/redo and grouping
- draw chessboard grid background on stage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4692f8d108321b36a74e3f31aa4a9