### PR TITLE
feat: restore element list and selection

### DIFF
--- a/src/actions/undo.js
+++ b/src/actions/undo.js
@@ -2,5 +2,6 @@ export default function undo(state) {
   const last = state.items.pop();
   if (last) {
     state.future.push(last);
+    state.selected?.delete?.(last.id);
   }
 }

--- a/src/editor/grouping.js
+++ b/src/editor/grouping.js
@@ -11,7 +11,7 @@ export function groupSelection(state) {
   if (selected.length < 2) return;
 
   const groupId = `group-${Date.now()}`;
-  state.items.push({ id: groupId, kind: 'group', children: selected });
+  state.items.push({ id: groupId, type: 'group', children: selected });
   state.selected = new Set([groupId]);
 }
 
@@ -24,7 +24,7 @@ export function groupSelection(state) {
 export function ungroupSelection(state) {
   const groups = Array.from(state.selected || [])
     .map(id => state.items.find(it => it.id === id))
-    .filter(it => it && it.kind === 'group');
+    .filter(it => it && it.type === 'group');
   if (groups.length === 0) return;
 
   for (const group of groups) {

--- a/src/editor/shortcuts.js
+++ b/src/editor/shortcuts.js
@@ -1,8 +1,12 @@
+import undo from '../actions/undo.js';
+import redo from '../actions/redo.js';
+
 /**
  * Registers a minimal set of keyboard shortcuts.  The editor instance
  * passed in is expected to expose methods such as `setTool` and
  * `groupSelection`.
  */
+
 export function registerShortcuts(editor) {
   const shortcuts = {
     g: () => editor.groupSelection(),
@@ -13,6 +17,27 @@ export function registerShortcuts(editor) {
 
   window.addEventListener('keydown', e => {
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+    // handle Ctrl/Meta combos
+    if (e.ctrlKey || e.metaKey) {
+      switch (e.key.toLowerCase()) {
+        case 'z':
+          e.preventDefault();
+          if (e.shiftKey) {
+            redo(editor.state);
+          } else {
+            undo(editor.state);
+          }
+          editor.updateElemList();
+          editor.redraw();
+          return;
+        case 'g':
+          e.preventDefault();
+          if (e.shiftKey) editor.ungroupSelection(); else editor.groupSelection();
+          return;
+      }
+    }
+
     const key = e.key.toLowerCase();
     if (shortcuts[key]) {
       e.preventDefault();

--- a/src/tools/EllipseTool.js
+++ b/src/tools/EllipseTool.js
@@ -29,7 +29,7 @@ export default class EllipseTool {
     if (!this.drawing) return;
     this.drawing = false;
     const { offsetX, offsetY } = e;
-    this.editor.state.items.push({
+    this.editor.addItem({
       type: 'ellipse',
       x: Math.min(this.startX, offsetX),
       y: Math.min(this.startY, offsetY),
@@ -38,6 +38,5 @@ export default class EllipseTool {
       strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
       strokeColor: this.editor.ui.strokeColor.value
     });
-    this.editor.redraw();
   }
 }

--- a/src/tools/LineTool.js
+++ b/src/tools/LineTool.js
@@ -29,7 +29,7 @@ export default class LineTool {
     if (!this.drawing) return;
     this.drawing = false;
     const { offsetX, offsetY } = e;
-    this.editor.state.items.push({
+    this.editor.addItem({
       type: 'line',
       x1: this.startX,
       y1: this.startY,
@@ -38,6 +38,5 @@ export default class LineTool {
       strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
       strokeColor: this.editor.ui.strokeColor.value
     });
-    this.editor.redraw();
   }
 }

--- a/src/tools/MoveTool.js
+++ b/src/tools/MoveTool.js
@@ -1,8 +1,44 @@
 export default class MoveTool {
   constructor(editor) {
     this.editor = editor;
+    this.dragging = false;
+    this.lastX = 0;
+    this.lastY = 0;
   }
-  start() {}
-  move() {}
-  end() {}
+  start(e) {
+    const hit = this.editor.hitTest(e.offsetX, e.offsetY);
+    if (hit) {
+      if (!this.editor.state.selected.has(hit.id)) {
+        this.editor.state.selected.clear();
+        this.editor.state.selected.add(hit.id);
+        this.editor.updateElemList();
+      }
+      this.dragging = true;
+      this.lastX = e.offsetX;
+      this.lastY = e.offsetY;
+    }
+  }
+  move(e) {
+    if (!this.dragging) return;
+    const dx = e.offsetX - this.lastX;
+    const dy = e.offsetY - this.lastY;
+    this.lastX = e.offsetX;
+    this.lastY = e.offsetY;
+    for (const item of this.editor.state.items) {
+      if (!this.editor.state.selected.has(item.id)) continue;
+      switch (item.type) {
+        case 'line':
+          item.x1 += dx; item.y1 += dy; item.x2 += dx; item.y2 += dy; break;
+        case 'rect':
+        case 'ellipse':
+          item.x += dx; item.y += dy; break;
+        case 'quadratic':
+          item.x1 += dx; item.y1 += dy; item.x2 += dx; item.y2 += dy; break;
+      }
+    }
+    this.editor.redraw();
+  }
+  end() {
+    this.dragging = false;
+  }
 }

--- a/src/tools/QuadraticTool.js
+++ b/src/tools/QuadraticTool.js
@@ -29,7 +29,7 @@ export default class QuadraticTool {
     if (!this.drawing) return;
     this.drawing = false;
     const { offsetX, offsetY } = e;
-    this.editor.state.items.push({
+    this.editor.addItem({
       type: 'quadratic',
       x1: this.startX,
       y1: this.startY,
@@ -38,6 +38,5 @@ export default class QuadraticTool {
       strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
       strokeColor: this.editor.ui.strokeColor.value
     });
-    this.editor.redraw();
   }
 }

--- a/src/tools/RectTool.js
+++ b/src/tools/RectTool.js
@@ -29,7 +29,7 @@ export default class RectTool {
     if (!this.drawing) return;
     this.drawing = false;
     const { offsetX, offsetY } = e;
-    this.editor.state.items.push({
+    this.editor.addItem({
       type: 'rect',
       x: Math.min(this.startX, offsetX),
       y: Math.min(this.startY, offsetY),
@@ -38,6 +38,5 @@ export default class RectTool {
       strokeWidth: this.editor.ui.strokeWidth.valueAsNumber || 1,
       strokeColor: this.editor.ui.strokeColor.value
     });
-    this.editor.redraw();
   }
 }

--- a/src/tools/SelectTool.js
+++ b/src/tools/SelectTool.js
@@ -2,7 +2,19 @@ export default class SelectTool {
   constructor(editor) {
     this.editor = editor;
   }
-  start() {}
+  start(e) {
+    const hit = this.editor.hitTest(e.offsetX, e.offsetY);
+    if (!e.shiftKey) this.editor.state.selected.clear();
+    if (hit) {
+      if (this.editor.state.selected.has(hit.id) && e.shiftKey) {
+        this.editor.state.selected.delete(hit.id);
+      } else {
+        this.editor.state.selected.add(hit.id);
+      }
+    }
+    this.editor.updateElemList();
+    this.editor.redraw();
+  }
   move() {}
   end() {}
 }

--- a/styles/editor.css
+++ b/styles/editor.css
@@ -252,7 +252,12 @@
 
         .stage-wrap {
             position: relative;
-            overflow: hidden
+            overflow: hidden;
+            /* chessboard style background */
+            background-image:
+                    linear-gradient(0deg, var(--grid) 1px, transparent 1px),
+                    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+            background-size: 20px 20px
         }
 
         canvas {


### PR DESCRIPTION
## Summary
- list drawn elements in sidebar with selection highlighting
- enable selecting elements on canvas and moving them
- refresh element list for undo/redo and grouping actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4692f8d108321b36a74e3f31aa4a9