### PR TITLE
refactor: split toolbar styles

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,3 +14,50 @@
 .btn:hover { transform: translateY(-1px); }
 .btn.primary { background: linear-gradient(180deg, #2a3470, #23295a); border-color: #3a4278; }
 .btn.danger { background: linear-gradient(180deg, #6a2830, #4c1c22); border-color: #9c323d; }
+
+.shape-pop {
+  background: var(--panel);
+  border: 1px solid #2b315b;
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, .35);
+}
+
+.iconbtn {
+  color: #e8ecff;
+  background: #242a4d;
+  border: 1px solid #39468c;
+  border-radius: 10px;
+}
+
+.iconbtn:hover { background: #2b315b; }
+
+.seg {
+  border: 1px solid #2b315b;
+  border-radius: 12px;
+  background: var(--panel);
+}
+
+.color {
+  border: 1px solid #2b315b;
+  border-radius: 12px;
+  background: var(--panel);
+}
+
+.color input[type=color] {
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+}
+
+.help-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.help-btn:hover {
+  background: var(--panel-2);
+  color: var(--accent);
+}

--- a/css/main.css
+++ b/css/main.css
@@ -28,3 +28,51 @@ canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block
 .rot-h { position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #ffd77a; border: 1px solid #3b2f00; pointer-events: auto; cursor: grab; }
 .help { position: absolute; right: 12px; bottom: 12px; z-index: 5; background: rgba(31, 35, 56, .88); border: 1px solid #2b315b; border-radius: 12px; padding: 10px 12px; max-width: 420px; font-size: 12px; line-height: 1.6; }
 .hide { display: none !important; }
+
+.shape-menu { position: relative; }
+
+.shape-pop {
+  position: absolute;
+  top: 110%;
+  right: 0;
+  z-index: 20;
+  display: none;
+  padding: 8px;
+  grid-template-columns: repeat(6, 36px);
+  gap: 6px;
+}
+
+.shape-menu[aria-expanded=true] .shape-pop { display: grid; }
+
+.iconbtn {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+}
+
+.seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+.color {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+.color input[type=color] {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+}
+
+.help-btn {
+  padding: 6px;
+  display: grid;
+  place-items: center;
+}

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -48,13 +48,17 @@ export function initToolbar() {
     </div>
   `;
 
+  const menu = document.getElementById('shapeMenu');
+
   // رخدادها
   toolbar.addEventListener('click', e => {
     const btn = e.target.closest('[data-tool]');
-    if (btn) emit('tool:change', btn.dataset.tool);
+    if (btn) {
+      emit('tool:change', btn.dataset.tool);
+      menu.setAttribute('aria-expanded', 'false');
+    }
   });
   document.getElementById('shapeMenuBtn').addEventListener('click', () => {
-    const menu = document.getElementById('shapeMenu');
     const open = menu.getAttribute('aria-expanded') === 'true';
     menu.setAttribute('aria-expanded', String(!open));
   });


### PR DESCRIPTION
## Summary
- extract toolbar styles from old markup
- split structural and visual CSS between main.css and components.css
- toggle shape popover via aria-expanded when selecting tools

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185877c54832190a74c62d0bab3e6