### PR TITLE
Use SVG icons for toolbar buttons

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,3 +14,25 @@
 .btn:hover { transform: translateY(-1px); }
 .btn.primary { background: linear-gradient(180deg, #2a3470, #23295a); border-color: #3a4278; }
 .btn.danger { background: linear-gradient(180deg, #6a2830, #4c1c22); border-color: #9c323d; }
+
+.iconbtn {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  color: #e8ecff;
+  background: #242a4d;
+  border: 1px solid #39468c;
+  border-radius: 10px;
+}
+.iconbtn:hover { background: #2b315b; }
+
+.icon {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -5,14 +5,45 @@ export function initToolbar() {
   toolbar.innerHTML = `
     <div class="left">
       <div class="shape-menu" id="shapeMenu" aria-expanded="false">
-        <button id="shapeMenuBtn" class="btn">ابزارها</button>
+        <button id="shapeMenuBtn" class="btn" title="ابزارها">
+          <span style="display:inline-flex;gap:6px;align-items:center">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M3 6h18M3 12h12M3 18h6"/>
+            </svg>
+            ابزارها
+          </span>
+        </button>
         <div class="shape-pop" id="shapePop">
-          <button class="iconbtn" data-tool="select" title="انتخاب">S</button>
-          <button class="iconbtn" data-tool="move" title="جابجایی">M</button>
-          <button class="iconbtn" data-tool="line" title="خط">L</button>
-          <button class="iconbtn" data-tool="quadratic" title="منحنی">Q</button>
-          <button class="iconbtn" data-tool="rect" title="مستطیل">R</button>
-          <button class="iconbtn" data-tool="ellipse" title="بیضی">E</button>
+          <button class="iconbtn" data-tool="select" title="انتخاب">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M4 4l8 8-3 1 1 3-2 2-3-1-1-3z"/>
+            </svg>
+          </button>
+          <button class="iconbtn" data-tool="move" title="جابجایی">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M12 2v20M2 12h20M8 8l4-4 4 4M8 16l4 4 4-4"/>
+            </svg>
+          </button>
+          <button class="iconbtn" data-tool="line" title="خط">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M4 18L20 6"/>
+            </svg>
+          </button>
+          <button class="iconbtn" data-tool="quadratic" title="منحنی">
+            <svg class="icon" viewBox="0 0 24 24">
+              <path d="M4 18Q12 6 20 6"/>
+            </svg>
+          </button>
+          <button class="iconbtn" data-tool="rect" title="مستطیل">
+            <svg class="icon" viewBox="0 0 24 24">
+              <rect x="4" y="6" width="16" height="12"/>
+            </svg>
+          </button>
+          <button class="iconbtn" data-tool="ellipse" title="بیضی">
+            <svg class="icon" viewBox="0 0 24 24">
+              <ellipse cx="12" cy="12" rx="8" ry="5"/>
+            </svg>
+          </button>
         </div>
       </div>
       <div class="seg">
@@ -44,7 +75,11 @@ export function initToolbar() {
       <button id="saveJSONMin" class="btn" title="ذخیره کمینه">ذخیره کمینه</button>
       <button id="exportPNG" class="btn" title="PNG">PNG</button>
       <button id="clear" class="btn danger" title="پاک کردن همه">پاک کردن</button>
-      <button id="helpBtn" class="help-btn" title="راهنما (H)">?</button>
+      <button id="helpBtn" class="help-btn" title="راهنما (H)">
+        <svg class="icon" viewBox="0 0 24 24">
+          <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-18a8 8 0 1 1 0 16 8 8 0 0 1 0-16zm1 13v-2h-2v2h2zm0-10v6h-2V7h2z"/>
+        </svg>
+      </button>
     </div>
   `;
 


### PR DESCRIPTION
## Summary
- replace placeholder letters in the toolbar with SVG icons
- style `.iconbtn` and `.icon` for proper sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185ab28c483218a1a2c4feeff3560