### PR TITLE
Wrap fill controls and centralize color styles

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,3 +14,22 @@
 .btn:hover { transform: translateY(-1px); }
 .btn.primary { background: linear-gradient(180deg, #2a3470, #23295a); border-color: #3a4278; }
 .btn.danger { background: linear-gradient(180deg, #6a2830, #4c1c22); border-color: #9c323d; }
+
+.color {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 12px;
+  border: 1px solid #2b315b;
+  background: var(--panel);
+}
+
+.color input[type=color] {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+}

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -1,4 +1,5 @@
-import { emit } from '../events.js';
+import { emit, on } from '../events.js';
+import { state } from '../state.js';
 
 export function initToolbar() {
   const toolbar = document.getElementById('toolbar');
@@ -25,8 +26,7 @@ export function initToolbar() {
     </div>
     <div class="center">
       <label>ضخامت <input id="strokeWidth" class="btn" type="number" min="1" max="24" value="3" style="width:70px"></label>
-      <span class="color"><label>رنگ خط</label><input id="strokeColor" type="color" value="#ffffff"/></span>
-      <span class="color"><label>پرشدن</label>
+      <span id="fillWrap" class="color"><label>پرشدن</label>
         <select id="fillMode" class="btn">
           <option value="hollow">توخالی</option>
           <option value="solid" selected>توپر</option>
@@ -34,6 +34,7 @@ export function initToolbar() {
         </select>
         <input id="fillColor" type="color" value="#66ccff"/>
       </span>
+      <span class="color"><label>رنگ خط</label><input id="strokeColor" type="color" value="#ffffff"/></span>
       <button id="undo" class="btn" title="واگرد (Ctrl+Z)">واگرد</button>
       <button id="redo" class="btn" title="از نو (Ctrl+Shift+Z)">از نو</button>
       <button id="apply" class="btn" title="ثبت (Enter)">اعمال</button>
@@ -48,14 +49,29 @@ export function initToolbar() {
     </div>
   `;
 
+  const fillWrap = document.getElementById('fillWrap');
+  const updateFillWrap = tool => {
+    const isShape = ['rect', 'ellipse'].includes(tool);
+    fillWrap.style.opacity = isShape ? 1 : 0.4;
+    fillWrap.style.pointerEvents = isShape ? 'auto' : 'none';
+  };
+
   // رخدادها
   toolbar.addEventListener('click', e => {
     const btn = e.target.closest('[data-tool]');
     if (btn) emit('tool:change', btn.dataset.tool);
   });
+
+  on('tool:change', e => {
+    state.tool = e.detail;
+    updateFillWrap(e.detail);
+  });
+
   document.getElementById('shapeMenuBtn').addEventListener('click', () => {
     const menu = document.getElementById('shapeMenu');
     const open = menu.getAttribute('aria-expanded') === 'true';
     menu.setAttribute('aria-expanded', String(!open));
   });
+
+  updateFillWrap(state.tool);
 }

--- a/old.html
+++ b/old.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>LinePack Pro — نسخه نهایی کامل</title>
+    <link rel="stylesheet" href="css/components.css"/>
     <style>
         :root {
             --bg: #0f1220;
@@ -168,25 +169,6 @@
             stroke-width: 1.6;
             stroke-linecap: round;
             stroke-linejoin: round
-        }
-
-        .color {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 4px 8px;
-            border-radius: 12px;
-            border: 1px solid #2b315b;
-            background: var(--panel)
-        }
-
-        .color input[type=color] {
-            width: 28px;
-            height: 28px;
-            padding: 0;
-            border: none;
-            background: transparent;
-            border-radius: 8px
         }
 
         .spacer {


### PR DESCRIPTION
## Summary
- wrap fill controls in `<span id="fillWrap" class="color">` and adjust order
- move `.color` style from inline CSS to `css/components.css`
- toggle fill controls based on selected tool

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185b9791483218d965b7c6b8aa12b