### PR TITLE
Add toggleable help panel

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -28,3 +28,7 @@ canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block
 .rot-h { position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #ffd77a; border: 1px solid #3b2f00; pointer-events: auto; cursor: grab; }
 .help { position: absolute; right: 12px; bottom: 12px; z-index: 5; background: rgba(31, 35, 56, .88); border: 1px solid #2b315b; border-radius: 12px; padding: 10px 12px; max-width: 420px; font-size: 12px; line-height: 1.6; }
 .hide { display: none !important; }
+.kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Courier New", monospace; font-size: 11px; background: #0b0e1a; border: 1px solid #2b315b; padding: 2px 6px; border-radius: 6px; color: #cdd5ff; }
+.badge { padding: 2px 8px; border-radius: 999px; background: #24305a; border: 1px solid #39468c; color: #cfe0ff; font-size: 11px; }
+.help-btn { background: none; border: none; color: var(--muted); cursor: pointer; padding: 6px; border-radius: 50%; display: grid; place-items: center; }
+.help-btn:hover { background: var(--panel-2); color: var(--accent); }

--- a/index.html
+++ b/index.html
@@ -16,7 +16,27 @@
       <canvas id="canvas"></canvas>
       <div id="ghost" class="ghost hide"></div>
       <div id="rotHandle" class="rot-h hide"></div>
-      <div id="help" class="help hide"></div>
+      <div id="help" class="help hide">
+        <strong>راهنما و کلیدهای میانبر</strong>
+        <ul>
+          <li><span class="kbd">H</span>: نمایش/مخفی راهنما</li>
+          <li><span class="kbd">S</span>: ابزار انتخاب</li>
+          <li><span class="kbd">M</span>: ابزار جابجایی</li>
+          <li><span class="kbd">L</span>: ابزار خط</li>
+          <li><span class="kbd">C</span>: ابزار منحنی</li>
+          <li><span class="kbd">R</span>: ابزار مستطیل</li>
+          <li><span class="kbd">E</span>: ابزار بیضی</li>
+          <li><span class="kbd">G</span>: گروه‌بندی المان‌ها</li>
+          <li><span class="kbd">U</span>: باز کردن گروه</li>
+          <li><span class="kbd">F2</span>: تغییر نام المان/گروه</li>
+          <li><span class="kbd">Delete</span>: حذف انتخاب‌شده‌ها</li>
+          <li><span class="kbd">Ctrl+S</span>: ذخیره پروژه</li>
+          <li><span class="kbd">Ctrl+O</span>: باز کردن پروژه</li>
+          <li><span class="kbd">Escape</span>: لغو عملیات جاری</li>
+          <li><span class="kbd">Enter</span>: اعمال رسم جاری</li>
+        </ul>
+        <div>فرمت ذخیره: <span class="badge">LinePack+Anim v2</span></div>
+      </div>
     </main>
   </div>
   <div id="timeline"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -49,6 +49,9 @@ function main() {
       state.items = []; state.selected.clear(); emit('draw'); emit('refreshList');
     }
   });
+  document.getElementById('helpBtn').addEventListener('click', () => {
+    document.getElementById('help').classList.toggle('hide');
+  });
   document.getElementById('fileInput').addEventListener('change', async e => {
     const f = e.target.files?.[0];
     if (!f) return;


### PR DESCRIPTION
## Summary
- Add help and shortcut text to `#help` container
- Toggle help panel visibility via `#helpBtn` click
- Style help elements and button in main stylesheet

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185d879bc8321a9fadf2dd82be51f