### PR TITLE
Extract sidebar and timeline styles

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -14,3 +14,6 @@
 .btn:hover { transform: translateY(-1px); }
 .btn.primary { background: linear-gradient(180deg, #2a3470, #23295a); border-color: #3a4278; }
 .btn.danger { background: linear-gradient(180deg, #6a2830, #4c1c22); border-color: #9c323d; }
+.badge { padding: 2px 8px; border-radius: 999px; background: #24305a; border: 1px solid #39468c; color: #cfe0ff; font-size: 11px; }
+.muted { color: var(--muted); }
+.kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Courier New", monospace; font-size: 11px; background: #0b0e1a; border: 1px solid #2b315b; padding: 2px 6px; border-radius: 6px; color: #cdd5ff; }

--- a/css/main.css
+++ b/css/main.css
@@ -21,9 +21,26 @@ body {
 }
 .content { flex: 1 1 auto; min-height: 0; display: grid; grid-template-columns: 270px 1fr; }
 .sidebar { background: linear-gradient(180deg, rgba(23, 26, 43, .96), rgba(23, 26, 43, .92)); border-left: 1px solid #2a3056; display: flex; flex-direction: column; }
+.tabs { display: grid; grid-template-columns: 1fr 1fr; }
+.tab { padding: 10px; text-align: center; border-bottom: 1px solid #2a3056; cursor: pointer; }
+.tab[aria-selected=true] { background: var(--panel-2); }
+.panel { flex: 1; overflow: auto; padding: 8px; }
+.list { display: grid; gap: 6px; }
+.row { display: grid; grid-template-columns: 28px 1fr auto auto; align-items: center; gap: 6px; padding: 6px 8px; border: 1px solid #2b315b; border-radius: 10px; background: var(--panel); }
+.row[aria-selected=true] { outline: 2px solid var(--accent-2); background: #20264a; }
+.sw { width: 16px; height: 16px; border-radius: 4px; border: 1px solid #2b315b; }
 .stage { position: relative; overflow: hidden; }
 canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; background: transparent; cursor: crosshair; }
 .timeline { flex: 0 0 auto; position: relative; background: #12162c; border-top: 1px solid #2a3056; height: 160px; }
+.tl-header { display: flex; align-items: center; gap: 8px; padding: 8px; border-bottom: 1px solid #2a3056; }
+.tl-body { position: absolute; inset: 48px 0 0 0; }
+.ticks { position: absolute; inset: 0; }
+.tick { position: absolute; top: 0; bottom: 0; width: 1px; background: #2b315b; }
+.tick.l { background: #39468c; }
+.tick .lab { position: absolute; top: -20px; transform: translateX(-50%); font-size: 11px; color: var(--muted); }
+.cursor { position: absolute; top: 0; bottom: 0; width: 2px; background: var(--accent); }
+.cursor.has-kf { background: var(--ok); }
+.playhead { position: absolute; top: 0; bottom: 0; width: 2px; background: #fff; opacity: .8; pointer-events: none; }
 .ghost { position: absolute; pointer-events: none; border: 1px dashed rgba(154, 123, 255, .8); border-radius: 8px; }
 .rot-h { position: absolute; width: 16px; height: 16px; border-radius: 50%; background: #ffd77a; border: 1px solid #3b2f00; pointer-events: auto; cursor: grab; }
 .help { position: absolute; right: 12px; bottom: 12px; z-index: 5; background: rgba(31, 35, 56, .88); border: 1px solid #2b315b; border-radius: 12px; padding: 10px 12px; max-width: 420px; font-size: 12px; line-height: 1.6; }


### PR DESCRIPTION
## Summary
- migrate sidebar structure styles from old.html into main.css
- add timeline subcomponent styles to main.css
- include utility classes for badges, muted text, and keyboard hints in components.css

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c1859f79288321a16407f9205ae942