### PR TITLE
feat: add rotation tool

### DIFF
--- a/js/tools/draw.js
+++ b/js/tools/draw.js
@@ -15,11 +15,10 @@ export function renderItem(ctx, item, showHandles = false) {
   ctx.lineCap = 'round'; ctx.lineJoin = 'round';
   ctx.strokeStyle = item.color; ctx.lineWidth = item.width;
   if (item.rot) {
-    const cx = item.kind === 'line' ? (item.p1.x + item.p2.x) / 2 : item.kind === 'quadratic' ? (item.p1.x + item.p2.x) / 2 : item.path.reduce((s, p) => s + p.x, 0) / item.path.length;
-    const cy = item.kind === 'line' ? (item.p1.y + item.p2.y) / 2 : item.kind === 'quadratic' ? (item.p1.y + item.p2.y) / 2 : item.path.reduce((s, p) => s + p.y, 0) / item.path.length;
-    ctx.translate(cx, cy);
+    const cen = itemCenter(item);
+    ctx.translate(cen.x, cen.y);
     ctx.rotate(item.rot * Math.PI / 180);
-    ctx.translate(-cx, -cy);
+    ctx.translate(-cen.x, -cen.y);
   }
   if (item.kind === 'line') {
     ctx.beginPath(); ctx.moveTo(item.p1.x, item.p1.y); ctx.lineTo(item.p2.x, item.p2.y); ctx.stroke();
@@ -46,4 +45,13 @@ function drawHandles(ctx, pts) {
     ctx.fill(); ctx.stroke();
   }
   ctx.restore();
+}
+
+function itemCenter(it) {
+  const pts = it.kind === 'line' ? [it.p1, it.p2]
+    : it.kind === 'quadratic' ? [it.p1, it.cp, it.p2]
+    : it.path;
+  const xs = pts.map(p => p.x);
+  const ys = pts.map(p => p.y);
+  return { x: (Math.min(...xs) + Math.max(...xs)) / 2, y: (Math.min(...ys) + Math.max(...ys)) / 2 };
 }

--- a/js/tools/manip.js
+++ b/js/tools/manip.js
@@ -3,6 +3,10 @@ import { emit } from '../events.js';
 import { pushHistory } from '../utils/history.js';
 import { rndId, snapIfNeeded } from '../utils/helpers.js';
 
+const rotDeg = document.getElementById('rotDeg');
+const rotHandle = document.getElementById('rotHandle');
+const ghost = document.getElementById('ghost');
+
 let dragging = null;
 
 export function onMouseMove(e) {
@@ -15,6 +19,26 @@ export function onMouseMove(e) {
       pts[dragging.keyIndex] = mp;
       setItemPoints(item, pts);
       emit('draw');
+      updateGhost();
+    } else if (dragging.type === 'move') {
+      const dx = mp.x - dragging.start.x;
+      const dy = mp.y - dragging.start.y;
+      dragging.start = mp;
+      for (const it of selectionItems()) {
+        const pts = itemPoints(it).map(p => ({ x: p.x + dx, y: p.y + dy }));
+        setItemPoints(it, pts);
+      }
+      emit('draw');
+      updateGhost();
+    } else if (dragging.type === 'rotate') {
+      const box = selectionBBox();
+      if (!box) return;
+      const ang = Math.atan2(mp.y - box.cy, mp.x - box.cx) * 180 / Math.PI - dragging.base;
+      const sel = selectionItems();
+      for (const it of sel) it.rot = (dragging.rot0.get(it.id) || 0) + ang;
+      rotDeg.value = Math.round(sel[0]?.rot || 0);
+      emit('draw');
+      updateGhost();
     }
     return;
   }
@@ -75,20 +99,29 @@ export function onMouseDown(e) {
       pushHistory();
       return;
     }
+    const box = selectionBBox();
+    if (box && mp.x >= box.x && mp.x <= box.x + box.w && mp.y >= box.y && mp.y <= box.y + box.h) {
+      dragging = { type: 'move', start: mp };
+      pushHistory();
+      return;
+    }
     const hitId = hitTestItem(mp);
     if (hitId) {
       if (!e.shiftKey) state.selected.clear();
       state.selected.add(hitId);
       emit('draw');
+      updateGhost();
     } else {
       if (!e.shiftKey) state.selected.clear();
       emit('draw');
+      updateGhost();
     }
   }
 }
 
 export function onMouseUp() {
   dragging = null;
+  rotHandle.style.cursor = 'grab';
 }
 
 function mousePos(e) {
@@ -159,6 +192,56 @@ function pointInPolygon(p, poly) {
   }
   return inside;
 }
+
+function selectionItems() {
+  return state.items.filter(it => state.selected.has(it.id));
+}
+
+function selectionBBox() {
+  const sel = selectionItems();
+  if (!sel.length) return null;
+  let xs = [], ys = [];
+  sel.forEach(it => itemPoints(it).forEach(p => { xs.push(p.x); ys.push(p.y); }));
+  const x1 = Math.min(...xs), y1 = Math.min(...ys), x2 = Math.max(...xs), y2 = Math.max(...ys);
+  return { x: x1, y: y1, w: x2 - x1, h: y2 - y1, cx: (x1 + x2) / 2, cy: (y1 + y2) / 2 };
+}
+
+export function updateGhost() {
+  const box = selectionBBox();
+  if (!box) {
+    ghost.classList.add('hide');
+    rotHandle.classList.add('hide');
+    return;
+  }
+  ghost.classList.remove('hide');
+  rotHandle.classList.remove('hide');
+  ghost.style.left = box.x + 'px';
+  ghost.style.top = box.y + 'px';
+  ghost.style.width = Math.max(0, box.w) + 'px';
+  ghost.style.height = Math.max(0, box.h) + 'px';
+  rotHandle.style.left = (box.cx - 8) + 'px';
+  rotHandle.style.top = (box.y - 26) + 'px';
+  rotDeg.value = Math.round(selectionItems()[0]?.rot || 0);
+}
+
+rotHandle.addEventListener('mousedown', e => {
+  const box = selectionBBox();
+  if (!box) return;
+  const mp = mousePos(e);
+  const base = Math.atan2(mp.y - box.cy, mp.x - box.cx) * 180 / Math.PI;
+  const rot0 = new Map();
+  selectionItems().forEach(it => rot0.set(it.id, it.rot || 0));
+  dragging = { type: 'rotate', base, rot0 };
+  rotHandle.style.cursor = 'grabbing';
+  pushHistory();
+});
+
+rotDeg.addEventListener('input', () => {
+  const deg = +rotDeg.value || 0;
+  for (const it of selectionItems()) it.rot = deg;
+  emit('draw');
+  updateGhost();
+});
 
 function commitDrawing() {
   if (!state.drawing) return;

--- a/js/ui/canvas.js
+++ b/js/ui/canvas.js
@@ -2,7 +2,7 @@ import { state } from '../state.js';
 import { emit, on } from '../events.js';
 import { CONFIG } from '../config.js';
 import { drawGrid, renderItem } from '../tools/draw.js';
-import { onMouseDown, onMouseMove, onMouseUp } from '../tools/manip.js';
+import { onMouseDown, onMouseMove, onMouseUp, updateGhost } from '../tools/manip.js';
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
@@ -22,6 +22,7 @@ export function initCanvas() {
   canvas.addEventListener('mousedown', onMouseDown);
   canvas.addEventListener('mousemove', onMouseMove);
   canvas.addEventListener('mouseup', onMouseUp);
+  window.addEventListener('mouseup', onMouseUp);
   draw();
 }
 
@@ -30,4 +31,5 @@ function draw() {
   drawGrid(ctx, canvas.width, canvas.height);
   for (const it of state.items) renderItem(ctx, it, state.selected.has(it.id));
   if (state.drawing) renderItem(ctx, state.drawing, true);
+  updateGhost();
 }


### PR DESCRIPTION
## Summary
- enable rotating selected items via degree input and draggable handle
- show rotation bounding box and handle for selections
- render items around bounding-box center for accurate rotation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c185e0b1ec8321a4be82dfd21bd70c