### PR TITLE
fix: close icon CSS rule

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -43,6 +43,7 @@
   stroke-width: 1.6;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
 
 .seg {
   border: 1px solid #2b315b;


### PR DESCRIPTION
## Summary
- close the `.icon` rule with a missing closing bracket in `components.css`

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c27c3269f48321bbf3bfcd2c42c2e5