### PR TITLE
feat: add animation sidebar controls

### DIFF
--- a/js/ui/sidebar.js
+++ b/js/ui/sidebar.js
@@ -1,6 +1,8 @@
 import { state } from '../state.js';
 import { emit } from '../events.js';
 import { pushHistory } from '../utils/history.js';
+import { rndId } from '../utils/helpers.js';
+import { rebuildTicks, placeCursor, putKeyframe, stepPlay, currentAnim } from './timeline.js';
 
 export function initSidebar() {
   const sidebar = document.getElementById('sidebar');
@@ -58,7 +60,59 @@ export function initSidebar() {
     }
   });
 
+  // دکمه‌های انیمیشن‌ها
+  const animName = document.getElementById('animName');
+  const animSelect = document.getElementById('animSelect');
+  const animDur = document.getElementById('animDur');
+  document.getElementById('addAnim').addEventListener('click', () => {
+    const name = animName.value.trim() || ('کلیپ ' + (state.animations.length + 1));
+    const id = rndId('anim');
+    state.animations.push({ id, name, duration: +animDur.value || 5, keyframes: [] });
+    state.currentAnimId = id;
+    refreshAnimSelect();
+    placeCursor();
+  });
+  document.getElementById('renameAnim').addEventListener('click', () => {
+    const a = currentAnim();
+    if (!a) return;
+    a.name = animName.value.trim() || a.name;
+    refreshAnimSelect();
+  });
+  document.getElementById('delAnim').addEventListener('click', () => {
+    if (!state.currentAnimId) return;
+    state.animations = state.animations.filter(a => a.id !== state.currentAnimId);
+    state.currentAnimId = state.animations[0]?.id || null;
+    refreshAnimSelect();
+    placeCursor();
+  });
+  animSelect.addEventListener('change', () => {
+    state.currentAnimId = animSelect.value;
+    const a = currentAnim();
+    if (a) {
+      animName.value = a.name;
+      animDur.value = a.duration;
+      rebuildTicks();
+      placeCursor();
+    }
+  });
+  animDur.addEventListener('change', () => {
+    const a = currentAnim();
+    if (a) a.duration = +animDur.value || 5;
+    rebuildTicks();
+    placeCursor();
+  });
+  document.getElementById('setKey').addEventListener('click', putKeyframe);
+  document.getElementById('play').addEventListener('click', () => {
+    const a = currentAnim();
+    if (!a || !a.keyframes.length) return;
+    state.tl.playing = true;
+    state.tl.startTime = performance.now() - state.tl.sec * 1000;
+    requestAnimationFrame(stepPlay);
+  });
+  document.getElementById('pause').addEventListener('click', () => { state.tl.playing = false; });
+
   refreshElemList();
+  refreshAnimSelect();
 }
 
 export function refreshElemList() {
@@ -85,4 +139,16 @@ export function refreshElemList() {
     row.querySelectorAll('svg')[1].addEventListener('click', e => { e.stopPropagation(); pushHistory(); state.items = state.items.filter(x => x.id !== it.id); state.selected.delete(it.id); refreshElemList(); emit('draw'); });
     list.appendChild(row);
   });
+}
+
+export function refreshAnimSelect() {
+  const sel = document.getElementById('animSelect');
+  sel.innerHTML = '';
+  state.animations.forEach(a => {
+    const opt = document.createElement('option');
+    opt.value = a.id;
+    opt.textContent = a.name;
+    sel.appendChild(opt);
+  });
+  if (state.currentAnimId) sel.value = state.currentAnimId;
 }

--- a/js/ui/timeline.js
+++ b/js/ui/timeline.js
@@ -30,6 +30,14 @@ export function initTimeline() {
   document.getElementById('tlPlay').addEventListener('click', togglePlay);
 }
 
+export function currentAnim() {
+  return state.animations.find(a => a.id === state.currentAnimId) || null;
+}
+
+export function snapshotState() {
+  return JSON.parse(JSON.stringify(state.items));
+}
+
 export function rebuildTicks() {
   const dur = +document.getElementById('animDur')?.value || 5;
   const ticks = document.getElementById('ticks');
@@ -69,16 +77,16 @@ function xToSec(x) {
 }
 
 function hasKeyAt(sec) {
-  const a = state.animations.find(a => a.id === state.currentAnimId);
+  const a = currentAnim();
   if (!a) return false;
   return a.keyframes.some(k => k.t === sec);
 }
 
-function putKeyframe() {
-  const a = state.animations.find(a => a.id === state.currentAnimId);
+export function putKeyframe() {
+  const a = currentAnim();
   if (!a) return;
   const t = state.tl.sec;
-  const snap = JSON.parse(JSON.stringify(state.items));
+  const snap = snapshotState();
   const idx = a.keyframes.findIndex(k => k.t === t);
   if (idx >= 0) a.keyframes[idx].snapshot = snap;
   else a.keyframes.push({ t, snapshot: snap });
@@ -87,7 +95,7 @@ function putKeyframe() {
 }
 
 function togglePlay() {
-  const a = state.animations.find(a => a.id === state.currentAnimId);
+  const a = currentAnim();
   if (!a || !a.keyframes.length) return;
   state.tl.playing = !state.tl.playing;
   if (state.tl.playing) {
@@ -96,9 +104,9 @@ function togglePlay() {
   }
 }
 
-function stepPlay(now) {
+export function stepPlay(now) {
   if (!state.tl.playing) return;
-  const a = state.animations.find(a => a.id === state.currentAnimId);
+  const a = currentAnim();
   if (!a) return;
   const dur = (a.duration || 5) * 1000;
   const tms = (now - state.tl.startTime) % dur;


### PR DESCRIPTION
## Summary
- add helpers for current animation state, keyframing, and playback
- hook up sidebar controls for managing animations
- rebuild timeline ticks when animation duration changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27c67830c832190e1c3eca5f24e43