### PR TITLE
Attach toolbar undo/redo/apply click handlers

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -19,6 +19,21 @@ window.addEventListener('keyup', e => {
 });
 function main() {
   initToolbar();
+  // ثبت رویدادهای دکمه‌های اصلی پس از ایجاد نوار ابزار
+  document.getElementById('undo').addEventListener('click', () => {
+    pushHistory();
+    undo();
+    emit('draw');
+    emit('refreshList');
+  });
+  document.getElementById('redo').addEventListener('click', () => {
+    pushHistory();
+    redo();
+    emit('draw');
+    emit('refreshList');
+  });
+  document.getElementById('apply').addEventListener('click', commitDrawing);
+
   initSidebar();
   initCanvas();
   initTimeline();


### PR DESCRIPTION
## Summary
- Register click listeners for undo, redo, and apply buttons once the toolbar is initialized

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c280273ab483218cc06f3806131c65