### PR TITLE
feat: refresh sidebar list after edits

### DIFF
--- a/js/ui/sidebar.js
+++ b/js/ui/sidebar.js
@@ -1,5 +1,5 @@
 import { state } from '../state.js';
-import { emit } from '../events.js';
+import { emit, on } from '../events.js';
 import { pushHistory } from '../utils/history.js';
 import { rndId } from '../utils/helpers.js';
 import { rebuildTicks, placeCursor, putKeyframe, stepPlay, currentAnim } from './timeline.js';
@@ -110,6 +110,7 @@ export function initSidebar() {
     requestAnimationFrame(stepPlay);
   });
   document.getElementById('pause').addEventListener('click', () => { state.tl.playing = false; });
+  on('refreshList', refreshElemList);
 
   refreshElemList();
   refreshAnimSelect();


### PR DESCRIPTION
## Summary
- update sidebar to listen for `refreshList` event and import `on`
- ensure element list refreshes after edits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c28056f0cc8321ae7c8ade29506870