### PR TITLE
Fix double delete shortcut

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -66,7 +66,6 @@ function main() {
     if (e.target.tagName === 'INPUT') return;
     if (e.key === 'Escape') { state.drawing = null; emit('draw'); }
     if (e.key === 'Enter') { commitDrawing(); }
-    if (e.key === 'Delete') { deleteSelection(); }
     if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey) { e.preventDefault(); pushHistory(); undo(); emit('draw'); emit('refreshList'); }
     if (e.ctrlKey && e.key.toLowerCase() === 'z' && e.shiftKey) { e.preventDefault(); pushHistory(); redo(); emit('draw'); emit('refreshList'); }
     if (e.ctrlKey && e.key.toLowerCase() === 'g' && !e.shiftKey) { e.preventDefault(); groupSelection(); }


### PR DESCRIPTION
## Summary
- Remove duplicate Delete key handler so selection deletes only once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2805f9e888321a3adb03c5c242970