### PR TITLE
Handle group deletion in sidebar

### DIFF
--- a/js/ui/sidebar.js
+++ b/js/ui/sidebar.js
@@ -188,13 +188,15 @@ function createRow(it, isGroup = false) {
     ev.stopPropagation();
     pushHistory();
     if (it.kind === 'group') {
-      state.items = state.items.filter(item => item.id !== it.id && !(it.children || []).includes(item.id));
+      const childIds = it.children || [];
+      state.items = state.items.filter(item => item.id !== it.id && !childIds.includes(item.id));
+      childIds.forEach(id => state.selected.delete(id));
     } else {
       state.items = state.items.filter(x => x.id !== it.id);
     }
     state.selected.delete(it.id);
-    refreshElemList();
     emit('draw');
+    emit('refreshList');
   });
 
   return row;


### PR DESCRIPTION
## Summary
- Ensure deleting a group removes all child items and deselects them
- Trigger redraw and list refresh via event bus after item deletion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c28459632c8321a5fc3f79a9931945