### PR TITLE
sync group visibility with children

### DIFF
--- a/js/ui/sidebar.js
+++ b/js/ui/sidebar.js
@@ -180,6 +180,17 @@ function createRow(it, isGroup = false) {
   eye.addEventListener('click', ev => {
     ev.stopPropagation();
     it.visible = it.visible === false ? true : false;
+    if (it.kind === 'group') {
+      const syncVisible = grp => {
+        (grp.children || []).forEach(childId => {
+          const child = state.items.find(item => item.id === childId);
+          if (!child) return;
+          child.visible = grp.visible;
+          if (child.kind === 'group') syncVisible(child);
+        });
+      };
+      syncVisible(it);
+    }
     refreshElemList();
     emit('draw');
   });


### PR DESCRIPTION
## Summary
- cascade visibility toggling from group items to their children when clicking the eye icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2850a1de483218db36a166873cc20