### PR TITLE
Allow fill changes on selected shapes

### DIFF
--- a/js/tools/manip.js
+++ b/js/tools/manip.js
@@ -142,6 +142,7 @@ export function onMouseDown(e) {
     if (hitId && !state.selected.has(hitId)) {
       if (!e.shiftKey) state.selected.clear();
       state.selected.add(hitId);
+      emit('selection:change');
       emit('draw');
       updateGhost();
     }
@@ -155,6 +156,7 @@ export function onMouseDown(e) {
     const hit = hitTestHandle(mp);
     if (hit) {
       state.selected.clear(); state.selected.add(hit.id);
+      emit('selection:change');
       dragging = { type: 'handle', id: hit.id, keyIndex: hit.keyIndex };
       pushHistory();
       return;
@@ -169,10 +171,12 @@ export function onMouseDown(e) {
     if (hitId) {
       if (!e.shiftKey) state.selected.clear();
       state.selected.add(hitId);
+      emit('selection:change');
       emit('draw');
       updateGhost();
     } else {
       if (!e.shiftKey) state.selected.clear();
+      emit('selection:change');
       emit('draw');
       updateGhost();
     }

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -85,8 +85,14 @@ export function initToolbar() {
   `;
 
   const fillWrap = document.getElementById('fillWrap');
-  const updateFillWrap = tool => {
-    const isShape = ['rect', 'ellipse'].includes(tool);
+  const fillMode = document.getElementById('fillMode');
+  const fillColor = document.getElementById('fillColor');
+  const updateFillWrap = () => {
+    const toolShape = ['rect', 'ellipse'].includes(state.tool);
+    const selShape = [...state.selected].some(id =>
+      state.items.find(it => it.id === id)?.kind === 'shape'
+    );
+    const isShape = toolShape || selShape;
     fillWrap.style.opacity = isShape ? 1 : 0.4;
     fillWrap.style.pointerEvents = isShape ? 'auto' : 'none';
   };
@@ -103,7 +109,11 @@ export function initToolbar() {
 
   on('tool:change', e => {
     state.tool = e.detail;
-    updateFillWrap(e.detail);
+    updateFillWrap();
+  });
+
+  on('selection:change', () => {
+    updateFillWrap();
   });
 
   document.getElementById('shapeMenuBtn').addEventListener('click', () => {
@@ -111,5 +121,34 @@ export function initToolbar() {
     menu.setAttribute('aria-expanded', String(!open));
   });
 
-  updateFillWrap(state.tool);
+  fillMode.addEventListener('change', () => {
+    const mode = fillMode.value;
+    const color = mode === 'hollow' ? null : fillColor.value;
+    const width = mode === 'fill' ? 0 : +document.getElementById('strokeWidth').value;
+    let changed = false;
+    state.selected.forEach(id => {
+      const it = state.items.find(x => x.id === id);
+      if (it && it.kind === 'shape') {
+        it.fill = color;
+        it.width = width;
+        changed = true;
+      }
+    });
+    if (changed) emit('draw');
+  });
+
+  fillColor.addEventListener('input', () => {
+    const color = fillColor.value;
+    let changed = false;
+    state.selected.forEach(id => {
+      const it = state.items.find(x => x.id === id);
+      if (it && it.kind === 'shape' && it.fill !== null) {
+        it.fill = color;
+        changed = true;
+      }
+    });
+    if (changed) emit('draw');
+  });
+
+  updateFillWrap();
 }


### PR DESCRIPTION
## Summary
- Enable fill controls when shape tools are active or shapes are selected
- Apply fill mode and color changes directly to selected shapes
- Emit and handle `selection:change` events to keep toolbar state in sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c29b337560832188572b6b1716c3df