### PR TITLE
Add undo/redo history manager and UI bindings

### DIFF
--- a/MANUAL_TEST.md
+++ b/MANUAL_TEST.md
@@ -1,0 +1,10 @@
+# Manual Test Plan
+
+## Undo/Redo history
+
+1. Open `old.html` in a modern browser.
+2. Draw several shapes.
+3. Ensure the **Undo** button activates once there is history.
+4. Press `Ctrl+Z` or click **Undo** repeatedly until all shapes disappear.
+5. Press `Ctrl+Shift+Z` or click **Redo** to restore shapes, verifying multiple cycles return drawings accurately.
+6. Confirm buttons disable when no further undo/redo is available.

--- a/js/app.js
+++ b/js/app.js
@@ -20,19 +20,6 @@ window.addEventListener('keyup', e => {
 });
 function main() {
   initToolbar();
-  // ثبت رویدادهای دکمه‌های اصلی پس از ایجاد نوار ابزار
-  document.getElementById('undo').addEventListener('click', () => {
-    pushHistory();
-    undo();
-    emit('draw');
-    emit('refreshList');
-  });
-  document.getElementById('redo').addEventListener('click', () => {
-    pushHistory();
-    redo();
-    emit('draw');
-    emit('refreshList');
-  });
   document.getElementById('apply').addEventListener('click', commitDrawing);
 
   initManip();
@@ -62,20 +49,19 @@ function main() {
   window.addEventListener('keydown', e => {
     const tag = e.target.tagName;
     if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-    if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey) {
-      e.preventDefault(); pushHistory(); undo(); emit('draw'); emit('refreshList');
-      return;
-    }
-    if (e.ctrlKey && e.key.toLowerCase() === 'z' && e.shiftKey) {
-      e.preventDefault(); pushHistory(); redo(); emit('draw'); emit('refreshList');
+    if (e.ctrlKey && e.key.toLowerCase() === 'z') {
+      e.preventDefault();
+      if (e.shiftKey) redo(); else undo();
       return;
     }
     if (e.ctrlKey && e.key.toLowerCase() === 's') {
-      e.preventDefault(); downloadBlob(JSON.stringify(exportJSON()), 'drawing.linepack.json');
+      e.preventDefault();
+      downloadBlob(JSON.stringify(exportJSON()), 'drawing.linepack.json');
       return;
     }
     if (e.ctrlKey && e.key.toLowerCase() === 'o') {
-      e.preventDefault(); document.getElementById('fileInput').click();
+      e.preventDefault();
+      document.getElementById('fileInput').click();
       return;
     }
     const key = e.key.toLowerCase();
@@ -83,15 +69,10 @@ function main() {
       e.preventDefault();
       shortcuts[key]();
     }
-    if (e.target.tagName === 'INPUT') return;
     if (e.key === 'Escape') { state.drawing = null; emit('draw'); }
     if (e.key === 'Enter') { commitDrawing(); }
-    if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey) { e.preventDefault(); pushHistory(); undo(); emit('draw'); emit('refreshList'); }
-    if (e.ctrlKey && e.key.toLowerCase() === 'z' && e.shiftKey) { e.preventDefault(); pushHistory(); redo(); emit('draw'); emit('refreshList'); }
     if (e.ctrlKey && e.key.toLowerCase() === 'g' && !e.shiftKey) { e.preventDefault(); groupSelection(); }
     if (e.ctrlKey && e.key.toLowerCase() === 'g' && e.shiftKey) { e.preventDefault(); ungroupSelection(); }
-    if (e.ctrlKey && e.key.toLowerCase() === 's') { e.preventDefault(); downloadBlob(JSON.stringify(exportJSON()), 'drawing.linepack.json'); }
-
   });
 
   // دکمه‌های اصلی

--- a/js/events.js
+++ b/js/events.js
@@ -1,3 +1,9 @@
 const bus = new EventTarget();
-export const emit = (name, detail) => bus.dispatchEvent(new CustomEvent(name, { detail }));
+
+export const emit = (name, detail) =>
+  bus.dispatchEvent(new CustomEvent(name, { detail }));
+
 export const on = (name, handler) => bus.addEventListener(name, handler);
+
+export const off = (name, handler) =>
+  bus.removeEventListener(name, handler);

--- a/js/ui/canvas.js
+++ b/js/ui/canvas.js
@@ -33,3 +33,7 @@ function draw() {
   if (state.drawing) renderItem(ctx, state.drawing, true);
   updateGhost();
 }
+
+export function redraw() {
+  draw();
+}

--- a/js/ui/toolbar.js
+++ b/js/ui/toolbar.js
@@ -1,5 +1,6 @@
 import { emit, on } from '../events.js';
 import { state } from '../state.js';
+import { undo, redo } from '../utils/history.js';
 
 export function initToolbar() {
   const toolbar = document.getElementById('toolbar');
@@ -87,6 +88,8 @@ export function initToolbar() {
   const fillWrap = document.getElementById('fillWrap');
   const fillMode = document.getElementById('fillMode');
   const fillColor = document.getElementById('fillColor');
+  const undoBtn = document.getElementById('undo');
+  const redoBtn = document.getElementById('redo');
   const updateFillWrap = () => {
     const toolShape = ['rect', 'ellipse'].includes(state.tool);
     const selShape = [...state.selected].some(id =>
@@ -151,4 +154,13 @@ export function initToolbar() {
   });
 
   updateFillWrap();
+
+  const updateHistoryBtns = () => {
+    undoBtn.disabled = state.history.length === 0;
+    redoBtn.disabled = state.future.length === 0;
+  };
+  undoBtn.addEventListener('click', () => undo());
+  redoBtn.addEventListener('click', () => redo());
+  on('history:update', updateHistoryBtns);
+  updateHistoryBtns();
 }

--- a/js/utils/history.js
+++ b/js/utils/history.js
@@ -1,24 +1,41 @@
 import { state } from '../state.js';
+import { emit } from '../events.js';
+
+const MAX_STACK = 50;
 
 export function pushHistory() {
-  state.history.push(JSON.stringify({ items: state.items, animations: state.animations }));
+  state.history.push(
+    JSON.stringify({ items: state.items, animations: state.animations })
+  );
+  if (state.history.length > MAX_STACK) state.history.shift();
   state.future.length = 0;
+  emit('history:update');
 }
 
 export function undo() {
   if (!state.history.length) return;
   const snap = state.history.pop();
-  state.future.push(JSON.stringify({ items: state.items, animations: state.animations }));
+  state.future.push(
+    JSON.stringify({ items: state.items, animations: state.animations })
+  );
   const s = JSON.parse(snap);
   state.items = s.items;
   state.animations = s.animations;
+  emit('history:update');
+  emit('draw');
+  emit('refreshList');
 }
 
 export function redo() {
   if (!state.future.length) return;
   const snap = state.future.pop();
-  state.history.push(JSON.stringify({ items: state.items, animations: state.animations }));
+  state.history.push(
+    JSON.stringify({ items: state.items, animations: state.animations })
+  );
   const s = JSON.parse(snap);
   state.items = s.items;
   state.animations = s.animations;
+  emit('history:update');
+  emit('draw');
+  emit('refreshList');
 }


### PR DESCRIPTION
## Summary
- add bounded history stack with undo/redo helpers
- wire toolbar buttons and keyboard shortcuts to history actions and redraw
- document manual testing for accurate undo/redo cycles

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c458e6588321881fb48dec0a1cec