### PR TITLE
Fix grouping near-hit handling

### DIFF
--- a/assets/scripts/layers/grouping.js
+++ b/assets/scripts/layers/grouping.js
@@ -195,16 +195,17 @@ function registerGrouping(ctx) {
             const aRef = add(a, prim);
             const bRef = add(b, prim);
             pts.push({ a: aRef, b: bRef, owner: owners[prim] });
+            return { a: aRef, b: bRef };
         }
 
         segs.forEach((seg, idx) => pushBase(seg.a, seg.b, idx));
 
         for (const hit of nearHits) {
             const { p, segA, segB } = hit;
-            const aRef = pushBase(p, p, segA);
-            const bRef = pushBase(p, p, segB);
-            aRef.segs.add(segB);
-            bRef.segs.add(segA);
+            const { a: refA } = pushBase(p, p, segA);
+            const { a: refB } = pushBase(p, p, segB);
+            refA.segs.add(segB);
+            refB.segs.add(segA);
         }
 
         const nodes = [...merged.values()];


### PR DESCRIPTION
## Summary
- ensure grouping intersection helper returns merged nodes for reuse
- update near-hit handling to attach segment references safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904845b885083218eee470bfe01b1fe