### PR TITLE
Preserve curve geometry when grouping into shapes

### DIFF
--- a/assets/scripts/layers/files.js
+++ b/assets/scripts/layers/files.js
@@ -41,7 +41,18 @@ function registerFileSystem(ctx) {
         const norm = p => ({ x: +(p.x / w).toFixed(min ? 3 : 6), y: +(p.y / h).toFixed(min ? 3 : 6) });
         if (it.kind === 'line') return { ...base, points: { p1: norm(it.p1), p2: norm(it.p2) } };
         if (it.kind === 'quadratic') return { ...base, points: { p1: norm(it.p1), cp: norm(it.cp), p2: norm(it.p2) } };
-        if (it.kind === 'shape') return { ...base, fill: it.fill || null, path: it.path.map(norm), children: it.children || [] };
+        if (it.kind === 'shape') {
+            const segs = Array.isArray(it.segments) ? it.segments.map(seg => {
+                if (!seg || !seg.p1 || !seg.p2) return null;
+                if (seg.kind === 'quadratic' && seg.cp) {
+                    return { kind: 'quadratic', p1: norm(seg.p1), cp: norm(seg.cp), p2: norm(seg.p2) };
+                }
+                return { kind: 'line', p1: norm(seg.p1), p2: norm(seg.p2) };
+            }).filter(Boolean) : null;
+            const out = { ...base, fill: it.fill || null, path: it.path.map(norm), children: it.children || [] };
+            if (segs && segs.length) out.segments = segs;
+            return out;
+        }
         if (it.kind === 'group') return { ...base, children: it.children?.slice() || [] };
         return base;
     }
@@ -87,7 +98,16 @@ function registerFileSystem(ctx) {
             return { ...base, p1: den(el.points.p1), cp: den(el.points.cp), p2: den(el.points.p2) };
         }
         if (el.kind === 'shape') {
-            return { ...base, path: (el.path || []).map(den), fill: el.fill || null, children: el.children || [] };
+            const segs = Array.isArray(el.segments) ? el.segments.map(seg => {
+                if (!seg || !seg.p1 || !seg.p2) return null;
+                if (seg.kind === 'quadratic' && seg.cp) {
+                    return { kind: 'quadratic', p1: den(seg.p1), cp: den(seg.cp), p2: den(seg.p2) };
+                }
+                return { kind: 'line', p1: den(seg.p1), p2: den(seg.p2) };
+            }).filter(Boolean) : [];
+            const shape = { ...base, path: (el.path || []).map(den), fill: el.fill || null, children: el.children || [] };
+            if (segs.length) shape.segments = segs;
+            return shape;
         }
         if (el.kind === 'group') {
             return { ...base, children: el.children?.slice() || [] };

--- a/assets/scripts/layers/grouping.js
+++ b/assets/scripts/layers/grouping.js
@@ -53,19 +53,23 @@ function registerGrouping(ctx) {
         }
 
         const mid = (a, b) => ({x: (a.x + b.x) / 2, y: (a.y + b.y) / 2});
+        const lerpPt = (A, B, t) => ({ x: A.x + (B.x - A.x) * t, y: A.y + (B.y - A.y) * t });
 
         function flattenQuadratic(p1, cp, p2, eps, maxDepth = 12) {
             const out = [];
-            (function rec(a, c, b, depth) {
+            (function rec(a, ta, c, tc, b, tb, depth) {
                 if (depth >= maxDepth || flatness2(a, c, b) <= eps * eps) {
-                    if (!out.length) out.push(a);
-                    out.push(b);
+                    if (!out.length) out.push({ pt: a, t: ta });
+                    out.push({ pt: b, t: tb });
                     return;
                 }
                 const a_c = mid(a, c), c_b = mid(c, b), m = mid(a_c, c_b);
-                rec(a, a_c, m, depth + 1);
-                rec(m, c_b, b, depth + 1);
-            })(p1, cp, p2, 0);
+                const tMid = (ta + tb) / 2;
+                const tcLeft = (ta + tc) / 2;
+                const tcRight = (tc + tb) / 2;
+                rec(a, ta, a_c, tcLeft, m, tMid, depth + 1);
+                rec(m, tMid, c_b, tcRight, b, tb, depth + 1);
+            })(p1, 0, cp, 0.5, p2, 1, 0);
             return out;
         }
 
@@ -122,28 +126,41 @@ function registerGrouping(ctx) {
 
         const avgW = Math.max(1, segObjs.reduce((s, it) => s + (+it.width || +it.style?.width || 1), 0) / segObjs.length);
 
-        const base = [];      // {a,b,len,prim}
+        const base = [];      // {a,b,len,prim,t0,t1,isCurve}
         const lengths = [];
 
-        function pushBase(a, b, prim) {
+        function pushBase(a, b, prim, t0 = 0, t1 = 1, isCurve = false) {
             const len = Math.hypot(b.x - a.x, b.y - a.y);
             if (len > 1e-3) {
-                base.push({a, b, len, prim});
+                base.push({a, b, len, prim, t0, t1, isCurve});
                 lengths.push(len);
             }
         }
 
-        for (let pi = 0; pi < segObjs.length; pi++) {
-            const it = segObjs[pi];
+        const segMeta = segObjs.map((it) => {
             if (it.kind === 'line') {
                 const [p1, p2] = getLineEnds(it);
-                if (p1 && p2) pushBase(toPx(p1), toPx(p2), pi);
-            } else {
+                if (p1 && p2) return { kind: 'line', p1: toPx(p1), p2: toPx(p2) };
+            } else if (it.kind === 'quadratic') {
                 const [p1, cp, p2] = getQuadEnds(it);
+                if (p1 && cp && p2) return { kind: 'quadratic', p1: toPx(p1), cp: toPx(cp), p2: toPx(p2) };
+            }
+            return null;
+        });
+
+        for (let pi = 0; pi < segObjs.length; pi++) {
+            const info = segMeta[pi];
+            if (!info) continue;
+            if (info.kind === 'line') {
+                pushBase(info.p1, info.p2, pi, 0, 1, false);
+            } else if (info.kind === 'quadratic') {
+                const { p1, cp, p2 } = info;
                 if (p1 && cp && p2) {
                     const FLAT_EPS = Math.max(0.9, Math.min(2.5, avgW * 0.45));
-                    const pts = flattenQuadratic(toPx(p1), toPx(cp), toPx(p2), FLAT_EPS, 12);
-                    for (let i = 1; i < pts.length; i++) pushBase(pts[i - 1], pts[i], pi);
+                    const pts = flattenQuadratic(p1, cp, p2, FLAT_EPS, 12);
+                    for (let i = 1; i < pts.length; i++) {
+                        pushBase(pts[i - 1].pt, pts[i].pt, pi, pts[i - 1].t, pts[i].t, true);
+                    }
                 }
             }
         }
@@ -203,14 +220,20 @@ function registerGrouping(ctx) {
             return Array.from(set).sort((a, b) => a - b).filter((v, i, a) => i === 0 || Math.abs(v - a[i - 1]) > 1e-6);
         }
 
-        const micro = []; // {a,b,prim}
+        const micro = []; // {a,b,prim,t0,t1,isCurve}
         for (let i = 0; i < base.length; i++) {
-            const A = base[i].a, B = base[i].b, prim = base[i].prim, ts = uniqSort(cuts[i]);
+            const seg = base[i];
+            const A = seg.a, B = seg.b, prim = seg.prim, ts = uniqSort(cuts[i]);
             for (let k = 0; k < ts.length - 1; k++) {
                 const t1 = ts[k], t2 = ts[k + 1];
                 const P = {x: A.x + (B.x - A.x) * t1, y: A.y + (B.y - A.y) * t1};
                 const Q = {x: A.x + (B.x - A.x) * t2, y: A.y + (B.y - A.y) * t2};
-                if (Math.hypot(Q.x - P.x, Q.y - P.y) > EDGE_MIN) micro.push({a: P, b: Q, prim});
+                if (Math.hypot(Q.x - P.x, Q.y - P.y) > EDGE_MIN) {
+                    const span = seg.t1 - seg.t0;
+                    const tStart = seg.t0 + span * t1;
+                    const tEnd = seg.t0 + span * t2;
+                    micro.push({a: P, b: Q, prim, t0: tStart, t1: tEnd, isCurve: seg.isCurve});
+                }
             }
         }
         if (!micro.length) return makePlainGroup(leafIds);
@@ -228,7 +251,8 @@ function registerGrouping(ctx) {
         }
 
         const E = []; // undirected edges [i,j]
-        const edgeOwner = new Map(); // 'min_max' -> prim
+        const edgeOwner = new Map(); // 'min_max' -> {prim, isCurve}
+        const edgeDir = new Map(); // 'a->b' -> {prim, isCurve, t0, t1, reversed: bool}
         const edgesAtV = new Map(); // v -> Set(prim)
 
         for (const e of micro) {
@@ -236,14 +260,17 @@ function registerGrouping(ctx) {
             if (A === B) continue;
             const ia = pts.indexOf(A), ib = pts.indexOf(B);
             const key = ia < ib ? ia + '_' + ib : ib + '_' + ia;
+            const ownerMeta = { prim: e.prim, isCurve: !!e.isCurve };
             if (!edgeOwner.has(key)) {
                 E.push([ia, ib]);
-                edgeOwner.set(key, e.prim);
+                edgeOwner.set(key, ownerMeta);
             }
             if (!edgesAtV.has(ia)) edgesAtV.set(ia, new Set());
             edgesAtV.get(ia).add(e.prim);
             if (!edgesAtV.has(ib)) edgesAtV.set(ib, new Set());
             edgesAtV.get(ib).add(e.prim);
+            edgeDir.set(ia + '->' + ib, { prim: e.prim, isCurve: !!e.isCurve, t0: e.t0, t1: e.t1, reversed: false });
+            edgeDir.set(ib + '->' + ia, { prim: e.prim, isCurve: !!e.isCurve, t0: e.t0, t1: e.t1, reversed: true });
         }
         if (!E.length) return makePlainGroup(leafIds);
 
@@ -303,7 +330,7 @@ function registerGrouping(ctx) {
         const ANG_EPS = 0.15; // ~8.6°
         function ownerOf(u, v) {
             const key = u < v ? u + '_' + v : v + '_' + u;
-            return edgeOwner.get(key);
+            return edgeOwner.get(key)?.prim;
         }
 
         function simplifyFaceIdx(idx) {
@@ -431,14 +458,81 @@ function registerGrouping(ctx) {
         }
         if (!uniq.length) return makePlainGroup(leafIds);
 
+        function splitQuadratic(p0, cp, p2, t) {
+            const p01 = lerpPt(p0, cp, t);
+            const p12 = lerpPt(cp, p2, t);
+            const p012 = lerpPt(p01, p12, t);
+            return {
+                left: { p0, cp: p01, p2: p012 },
+                right: { p0: p012, cp: p12, p2 }
+            };
+        }
+
+        function quadSegmentRange(p0, cp, p2, t0, t1) {
+            let seg = { p0, cp, p2 };
+            let start = Math.max(0, Math.min(1, t0));
+            let end = Math.max(0, Math.min(1, t1));
+            if (end < start) [start, end] = [end, start];
+            if (start > 0) {
+                const split = splitQuadratic(seg.p0, seg.cp, seg.p2, start);
+                seg = split.right;
+                const span = Math.max(1e-6, 1 - start);
+                end = (end - start) / span;
+            }
+            if (end < 1) {
+                const split = splitQuadratic(seg.p0, seg.cp, seg.p2, end);
+                seg = split.left;
+            }
+            return seg;
+        }
+
         // ---------- 6) Build shapes + delete source segments ----------
         api.pushHistory && api.pushHistory();
         const made = [];
         for (const f of uniq) {
             const pathOut = f.path.map(p => fromPx(p, srcNorm));
+            const segments = [];
+            const idxCycle = f.idx || [];
+            for (let i = 0; i < idxCycle.length; i++) {
+                const u = idxCycle[i];
+                const v = idxCycle[(i + 1) % idxCycle.length];
+                const key = u + '->' + v;
+                const meta = edgeDir.get(key);
+                const startPx = pts[u];
+                const endPx = pts[v];
+                if (meta && segMeta[meta.prim]) {
+                    const info = segMeta[meta.prim];
+                    if (meta.isCurve && info?.kind === 'quadratic') {
+                        const seg = quadSegmentRange(info.p1, info.cp, info.p2, meta.t0, meta.t1);
+                        let segOut = {
+                            kind: 'quadratic',
+                            p1: fromPx(seg.p0, srcNorm),
+                            cp: fromPx(seg.cp, srcNorm),
+                            p2: fromPx(seg.p2, srcNorm)
+                        };
+                        if (meta.reversed) {
+                            segOut = {
+                                kind: 'quadratic',
+                                p1: segOut.p2,
+                                cp: segOut.cp,
+                                p2: segOut.p1
+                            };
+                        }
+                        segments.push(segOut);
+                    } else {
+                        let p1Out = fromPx(startPx, srcNorm);
+                        let p2Out = fromPx(endPx, srcNorm);
+                        if (meta.reversed) [p1Out, p2Out] = [p2Out, p1Out];
+                        segments.push({ kind: 'line', p1: p1Out, p2: p2Out });
+                    }
+                } else {
+                    segments.push({ kind: 'line', p1: fromPx(startPx, srcNorm), p2: fromPx(endPx, srcNorm) });
+                }
+            }
             const shape = {
                 id: (typeof rndId === 'function') ? rndId('shape') : ('shape_' + Math.random().toString(36).slice(2)),
                 kind: 'shape', path: pathOut,
+                segments,
                 color: ui?.strokeColor?.value ?? '#fff',
                 width: +ui?.strokeWidth?.value || 1.5,
                 fill: ui?.fillColor?.value ?? 'transparent',

--- a/assets/scripts/layers/rendering.js
+++ b/assets/scripts/layers/rendering.js
@@ -82,23 +82,50 @@ function registerRendering(ctx) {
                 drawHandles([item.p1, item.cp, item.p2]);
             }
         } else if (item.kind === 'shape') {
-            const path = item.path;
-            if (!path.length) {
-                canvasCtx.restore();
-                return;
+            const segs = Array.isArray(item.segments) ? item.segments.filter(seg => seg && seg.p1 && seg.p2) : [];
+            if (segs.length) {
+                canvasCtx.beginPath();
+                canvasCtx.moveTo(segs[0].p1.x, segs[0].p1.y);
+                for (const seg of segs) {
+                    if (seg.kind === 'quadratic' && seg.cp) {
+                        canvasCtx.quadraticCurveTo(seg.cp.x, seg.cp.y, seg.p2.x, seg.p2.y);
+                    } else {
+                        canvasCtx.lineTo(seg.p2.x, seg.p2.y);
+                    }
+                }
+                canvasCtx.closePath();
+                if (item.fill) {
+                    canvasCtx.fillStyle = item.fill;
+                    canvasCtx.fill();
+                }
+                if (item.width > 0) canvasCtx.stroke();
+                if (showHandles) {
+                    const handles = [];
+                    for (const seg of segs) {
+                        handles.push(seg.p1, seg.p2);
+                        if (seg.kind === 'quadratic' && seg.cp) handles.push(seg.cp);
+                    }
+                    drawHandles(handles.filter(Boolean));
+                }
+            } else {
+                const path = item.path;
+                if (!path.length) {
+                    canvasCtx.restore();
+                    return;
+                }
+                canvasCtx.beginPath();
+                canvasCtx.moveTo(path[0].x, path[0].y);
+                for (let i = 1; i < path.length; i++) {
+                    canvasCtx.lineTo(path[i].x, path[i].y);
+                }
+                canvasCtx.closePath();
+                if (item.fill) {
+                    canvasCtx.fillStyle = item.fill;
+                    canvasCtx.fill();
+                }
+                if (item.width > 0) canvasCtx.stroke();
+                if (showHandles) drawHandles(path);
             }
-            canvasCtx.beginPath();
-            canvasCtx.moveTo(path[0].x, path[0].y);
-            for (let i = 1; i < path.length; i++) {
-                canvasCtx.lineTo(path[i].x, path[i].y);
-            }
-            canvasCtx.closePath();
-            if (item.fill) {
-                canvasCtx.fillStyle = item.fill;
-                canvasCtx.fill();
-            }
-            if (item.width > 0) canvasCtx.stroke();
-            if (showHandles) drawHandles(path);
         }
         canvasCtx.restore();
     }

--- a/assets/scripts/layers/selection.js
+++ b/assets/scripts/layers/selection.js
@@ -5,7 +5,7 @@
 
 function registerSelection(ctx) {
     const { state, ui, utils, canvas, api } = ctx;
-    const { rndId, dist } = utils;
+    const { rndId, dist, quadAt } = utils;
 
     function selectionLeafItems() {
         const out = [];
@@ -148,11 +148,32 @@ function registerSelection(ctx) {
                     prev = pt;
                 }
             } else if (item.kind === 'shape') {
-                for (let i = 0; i < item.path.length; i++) {
-                    const a = item.path[i];
-                    const b = item.path[(i + 1) % item.path.length];
-                    edges.push([a, b]);
-                    pts.push(a, b);
+                const segs = Array.isArray(item.segments) && item.segments.length ? item.segments : null;
+                if (segs) {
+                    for (const seg of segs) {
+                        if (!seg || !seg.p1 || !seg.p2) continue;
+                        if (seg.kind === 'quadratic' && seg.cp) {
+                            const N = 32;
+                            let prev = seg.p1;
+                            for (let i = 1; i <= N; i++) {
+                                const t = i / N;
+                                const q = quadAt(seg.p1, seg.cp, seg.p2, t);
+                                edges.push([prev, q]);
+                                pts.push(prev, q);
+                                prev = q;
+                            }
+                        } else {
+                            edges.push([seg.p1, seg.p2]);
+                            pts.push(seg.p1, seg.p2);
+                        }
+                    }
+                } else {
+                    for (let i = 0; i < item.path.length; i++) {
+                        const a = item.path[i];
+                        const b = item.path[(i + 1) % item.path.length];
+                        edges.push([a, b]);
+                        pts.push(a, b);
+                    }
                 }
             }
         }

--- a/assets/scripts/layers/timeline.js
+++ b/assets/scripts/layers/timeline.js
@@ -103,6 +103,12 @@ function registerTimeline(ctx) {
             for (let i = 0; i < n; i++) path.push(lpt(a.path[i], b.path[i], t));
             o.path = path;
             o.fill = t < 0.5 ? a.fill : b.fill;
+            const segA = Array.isArray(a.segments) ? a.segments : null;
+            const segB = Array.isArray(b.segments) ? b.segments : null;
+            if (segA || segB) {
+                const src = t < 0.5 ? (segA || segB) : (segB || segA);
+                o.segments = src ? JSON.parse(JSON.stringify(src)) : undefined;
+            }
         }
         return o;
     }


### PR DESCRIPTION
## Summary
- keep track of original segment metadata during grouping and attach curve-aware `segments` data to new shapes
- render grouped shapes using their curve segments and expose those segments through import/export, selection, and timeline utilities

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_69048c568a508321bc9459906b63f51f