### PR TITLE
Add resize handles to selection overlay

### DIFF
--- a/assets/scripts/core/dom.js
+++ b/assets/scripts/core/dom.js
@@ -53,6 +53,7 @@ export const UI = {
     delAnim: document.getElementById('delAnim'),
     ghost: document.getElementById('ghost'),
     rotHandle: document.getElementById('rotHandle'),
+    scaleHandles: Array.from(document.querySelectorAll('.scale-h')),
     apply: document.getElementById('apply'),
     help: document.getElementById('help'),
     fillEnabled: document.getElementById('fillEnabled'),

--- a/assets/scripts/layers/input.js
+++ b/assets/scripts/layers/input.js
@@ -4,7 +4,7 @@
  */
 
 function registerInput(ctx) {
-    const { state, ui, utils, canvas, api } = ctx;
+    const { state, ui, utils, canvas, stageWrap, api } = ctx;
     const { rndId, itemPoints, setItemPoints } = utils;
     const keys = { ctrl: false, shift: false };
     ctx.dragging = null;
@@ -108,6 +108,25 @@ function registerInput(ctx) {
                     it.rot = (ctx.dragging.rot0.get(it.id) || 0) + ang;
                 }
                 ui.rotDeg.value = Math.round((leafs[0]?.rot || 0));
+                api.draw && api.draw();
+                api.updateGhost && api.updateGhost();
+            } else if (ctx.dragging.type === 'scale') {
+                const { center, baseVec, baseLen, points0 } = ctx.dragging;
+                const dot = (mp.x - center.x) * baseVec.x + (mp.y - center.y) * baseVec.y;
+                let scale = baseLen ? dot / (baseLen * baseLen) : 1;
+                if (!Number.isFinite(scale) || Number.isNaN(scale)) scale = 1;
+                scale = Math.abs(scale);
+                scale = Math.max(0.02, Math.min(scale, 100));
+                const leafs = api.selectionLeafItems ? api.selectionLeafItems() : [];
+                for (const it of leafs) {
+                    const pts0 = points0.get(it.id);
+                    if (!pts0) continue;
+                    const next = pts0.map(p0 => ({
+                        x: center.x + (p0.x - center.x) * scale,
+                        y: center.y + (p0.y - center.y) * scale
+                    }));
+                    setItemPoints(it, next);
+                }
                 api.draw && api.draw();
                 api.updateGhost && api.updateGhost();
             }
@@ -293,7 +312,7 @@ function registerInput(ctx) {
         if (e.key === 'Shift') keys.shift = false;
     });
 
-    canvas.addEventListener('mousemove', onMouseMove);
+    stageWrap?.addEventListener('mousemove', onMouseMove);
     canvas.addEventListener('mousedown', onMouseDown);
     window.addEventListener('mouseup', () => {
         ctx.dragging = null;

--- a/assets/scripts/layers/ui.js
+++ b/assets/scripts/layers/ui.js
@@ -4,7 +4,8 @@
  */
 
 function registerUI(ctx) {
-    const { state, ui, api } = ctx;
+    const { state, ui, api, utils } = ctx;
+    const { itemPoints } = utils;
 
     function niceName(it) {
         return it.name || (it.kind === 'line' ? 'خط' : it.kind === 'quadratic' ? 'منحنی' : 'شکل');
@@ -105,9 +106,11 @@ function registerUI(ctx) {
 
     function updateGhost() {
         const box = api.selectionBBox ? api.selectionBBox() : null;
-        if (!box) {
+        const handles = ui.scaleHandles || [];
+        if (!box || state.tool !== 'select') {
             ui.ghost.classList.add('hide');
             ui.rotHandle.classList.add('hide');
+            handles.forEach(h => h.classList.add('hide'));
             return;
         }
         ui.ghost.classList.remove('hide');
@@ -118,6 +121,23 @@ function registerUI(ctx) {
         ui.ghost.style.height = Math.max(0, box.h) + 'px';
         ui.rotHandle.style.left = (box.cx - 8) + 'px';
         ui.rotHandle.style.top = (box.y - 26) + 'px';
+        const positions = {
+            nw: { x: box.x, y: box.y },
+            ne: { x: box.x + box.w, y: box.y },
+            se: { x: box.x + box.w, y: box.y + box.h },
+            sw: { x: box.x, y: box.y + box.h }
+        };
+        handles.forEach(handle => {
+            const dir = handle.dataset.dir;
+            const pos = positions[dir];
+            if (!pos) {
+                handle.classList.add('hide');
+                return;
+            }
+            handle.classList.remove('hide');
+            handle.style.left = (pos.x - 7) + 'px';
+            handle.style.top = (pos.y - 7) + 'px';
+        });
     }
 
     ui.helpBtn.addEventListener('click', () => {
@@ -176,6 +196,39 @@ function registerUI(ctx) {
         ctx.dragging = { type: 'rotate', base, rot0 };
         ui.rotHandle.style.cursor = 'grabbing';
         api.pushHistory && api.pushHistory();
+    });
+
+    function cornerPos(box, dir) {
+        if (!box) return null;
+        const lookup = {
+            nw: { x: box.x, y: box.y },
+            ne: { x: box.x + box.w, y: box.y },
+            se: { x: box.x + box.w, y: box.y + box.h },
+            sw: { x: box.x, y: box.y + box.h }
+        };
+        return lookup[dir] || null;
+    }
+
+    (ui.scaleHandles || []).forEach(handle => {
+        handle.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const dir = handle.dataset.dir;
+            const box = api.selectionBBox ? api.selectionBBox() : null;
+            if (!box) return;
+            const center = { x: box.cx, y: box.cy };
+            const corner = cornerPos(box, dir);
+            if (!corner) return;
+            const baseVec = { x: corner.x - center.x, y: corner.y - center.y };
+            const baseLen = Math.hypot(baseVec.x, baseVec.y) || 1;
+            const points0 = new Map();
+            (api.selectionLeafItems ? api.selectionLeafItems() : []).forEach(it => {
+                const pts = itemPoints(it).map(p => ({ x: p.x, y: p.y }));
+                points0.set(it.id, pts);
+            });
+            ctx.dragging = { type: 'scale', dir, center, baseVec, baseLen, points0 };
+            api.pushHistory && api.pushHistory();
+        });
     });
 
     ui.rotDeg.addEventListener('change', () => {

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -309,6 +309,27 @@
             cursor: grab
         }
 
+        .scale-h {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            border-radius: 4px;
+            background: rgba(155, 123, 255, .95);
+            border: 1px solid #2e1f58;
+            box-shadow: 0 0 0 1px rgba(0, 0, 0, .35);
+            pointer-events: auto;
+        }
+
+        .scale-h[data-dir="nw"],
+        .scale-h[data-dir="se"] {
+            cursor: nwse-resize
+        }
+
+        .scale-h[data-dir="ne"],
+        .scale-h[data-dir="sw"] {
+            cursor: nesw-resize
+        }
+
         /* ===== Timeline (bottom) ===== */
         .timeline {
             flex: 0 0 auto;

--- a/index.html
+++ b/index.html
@@ -155,6 +155,10 @@
         <!-- Selection visuals -->
         <div class="ghost hide" id="ghost"></div>
         <div class="rot-h hide" id="rotHandle" title="چرخش"></div>
+        <div class="scale-h hide" data-dir="nw" title="تغییر اندازه"></div>
+        <div class="scale-h hide" data-dir="ne" title="تغییر اندازه"></div>
+        <div class="scale-h hide" data-dir="se" title="تغییر اندازه"></div>
+        <div class="scale-h hide" data-dir="sw" title="تغییر اندازه"></div>
     </section>
 </main>
 <!-- ===== Timeline pinned at bottom ===== -->


### PR DESCRIPTION
## Summary
- add corner resize handles to the selection overlay so users can scale shapes alongside rotation
- hook the new handles into the input and UI layers to scale selected geometry uniformly around its center
- style and expose the handles so they render consistently with the existing selection ghost

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69048dfe3bd4832185926ddc79608814