### PR TITLE
Simplify summary export format and allow reimport

### DIFF
--- a/assets/scripts/layers/files.js
+++ b/assets/scripts/layers/files.js
@@ -7,6 +7,256 @@ function registerFileSystem(ctx) {
     const { state, ui, canvas, api, utils } = ctx;
     const { rndId } = utils;
 
+    const PRECISION = 3;
+    const EPSILON = 1e-3;
+
+    const normPoint = (p, w, h) => {
+        if (!p || typeof p.x !== 'number' || typeof p.y !== 'number') return null;
+        return [+(p.x / w).toFixed(PRECISION), +(p.y / h).toFixed(PRECISION)];
+    };
+
+    const denormPoint = (pt, size) => {
+        if (!Array.isArray(pt) || pt.length < 2) return null;
+        const x = Number.isFinite(pt[0]) ? pt[0] : 0;
+        const y = Number.isFinite(pt[1]) ? pt[1] : 0;
+        return { x: x * size.w, y: y * size.h };
+    };
+
+    const simplifySegments = (shape, w, h) => {
+        const src = Array.isArray(shape.segments) && shape.segments.length
+            ? shape.segments
+            : (() => {
+                const path = Array.isArray(shape.path) ? shape.path : [];
+                if (path.length < 2) return [];
+                const segs = [];
+                for (let i = 0; i < path.length; i++) {
+                    const p1 = path[i];
+                    const p2 = path[(i + 1) % path.length];
+                    if (!p1 || !p2) continue;
+                    if (p1.x === p2.x && p1.y === p2.y) continue;
+                    segs.push({ kind: 'line', p1, p2 });
+                }
+                return segs;
+            })();
+        return src.map(seg => {
+            if (!seg || !seg.p1 || !seg.p2) return null;
+            const start = normPoint(seg.p1, w, h);
+            const end = normPoint(seg.p2, w, h);
+            if (!start || !end) return null;
+            if (seg.kind === 'quadratic' && seg.cp) {
+                const control = normPoint(seg.cp, w, h);
+                if (!control) return { type: 'line', start, end };
+                return { type: 'curve', start, control, end };
+            }
+            return { type: 'line', start, end };
+        }).filter(Boolean);
+    };
+
+    const simplifyItem = (it, w, h) => {
+        if (!it) return null;
+        const base = {
+            id: it.id,
+            type: it.kind,
+            color: it.color,
+            width: +it.width,
+            visible: it.visible !== false,
+            rotation: +(it.rot || 0)
+        };
+        if (it.kind === 'group') {
+            return {
+                ...base,
+                children: Array.isArray(it.children) ? it.children.slice() : []
+            };
+        }
+        if (it.kind === 'line') {
+            const start = normPoint(it.p1, w, h);
+            const end = normPoint(it.p2, w, h);
+            const geometry = start && end ? [{ type: 'line', start, end }] : [];
+            const out = { ...base };
+            if (geometry.length) out.geometry = geometry;
+            return out;
+        }
+        if (it.kind === 'quadratic') {
+            const start = normPoint(it.p1, w, h);
+            const end = normPoint(it.p2, w, h);
+            const control = normPoint(it.cp, w, h);
+            const geometry = (start && end && control)
+                ? [{ type: 'curve', start, control, end }]
+                : [];
+            const out = { ...base };
+            if (geometry.length) out.geometry = geometry;
+            return out;
+        }
+        if (it.kind === 'shape') {
+            const path = Array.isArray(it.path)
+                ? it.path.map(p => normPoint(p, w, h)).filter(Boolean)
+                : [];
+            const geometry = simplifySegments(it, w, h);
+            const children = Array.isArray(it.children) ? it.children.slice() : [];
+            const out = {
+                ...base,
+                type: 'shape',
+                fill: it.fill || null,
+                path,
+                children
+            };
+            if (geometry.length) out.geometry = geometry;
+            return out;
+        }
+        return base;
+    };
+
+    const inflateSegment = (seg, size) => {
+        if (!seg) return null;
+        const start = denormPoint(seg.start, size);
+        const end = denormPoint(seg.end, size);
+        if (!start || !end) return null;
+        if ((seg.type === 'curve' || seg.type === 'quadratic') && seg.control) {
+            const control = denormPoint(seg.control, size);
+            if (!control) return { kind: 'line', p1: start, p2: end };
+            return { kind: 'quadratic', p1: start, cp: control, p2: end };
+        }
+        return { kind: 'line', p1: start, p2: end };
+    };
+
+    const inflateItem = (entry, size) => {
+        if (!entry) return null;
+        const type = entry.type || entry.kind;
+        const base = {
+            id: entry.id || rndId('it'),
+            kind: type === 'curve' ? 'quadratic' : type,
+            color: entry.color || '#fff',
+            width: +(entry.width ?? 3),
+            rot: +(entry.rotation || 0),
+            visible: entry.visible !== false
+        };
+        if (base.kind === 'group') {
+            return {
+                ...base,
+                children: Array.isArray(entry.children) ? entry.children.slice() : []
+            };
+        }
+        if (base.kind === 'line') {
+            const geom = Array.isArray(entry.geometry) ? entry.geometry[0] : null;
+            const start = geom?.start || entry.start;
+            const end = geom?.end || entry.end;
+            const p1 = denormPoint(start, size);
+            const p2 = denormPoint(end, size);
+            if (!p1 || !p2) return null;
+            return { ...base, p1, p2 };
+        }
+        if (base.kind === 'quadratic') {
+            const geom = Array.isArray(entry.geometry) ? entry.geometry[0] : null;
+            const start = geom?.start || entry.start;
+            const end = geom?.end || entry.end;
+            const control = geom?.control || entry.control || entry.cp;
+            const p1 = denormPoint(start, size);
+            const p2 = denormPoint(end, size);
+            const cp = denormPoint(control, size);
+            if (!p1 || !p2 || !cp) return null;
+            return { ...base, p1, p2, cp };
+        }
+        if (base.kind === 'shape') {
+            const path = Array.isArray(entry.path)
+                ? entry.path.map(pt => denormPoint(pt, size)).filter(Boolean)
+                : [];
+            const geometry = Array.isArray(entry.geometry)
+                ? entry.geometry.map(seg => inflateSegment(seg, size)).filter(Boolean)
+                : [];
+            const children = Array.isArray(entry.children) ? entry.children.slice() : [];
+            const shape = {
+                ...base,
+                path,
+                fill: entry.fill || null,
+                children
+            };
+            if (!shape.path.length && geometry.length) {
+                const pts = [];
+                geometry.forEach(seg => {
+                    if (!pts.length || pts[pts.length - 1].x !== seg.p1.x || pts[pts.length - 1].y !== seg.p1.y) {
+                        pts.push({ x: seg.p1.x, y: seg.p1.y });
+                    }
+                });
+                if (geometry.length) {
+                    const last = geometry[geometry.length - 1].p2;
+                    if (!pts.length || pts[0].x !== last.x || pts[0].y !== last.y) pts.push({ x: last.x, y: last.y });
+                }
+                shape.path = pts;
+            }
+            if (geometry.length) shape.segments = geometry;
+            return shape;
+        }
+        return base;
+    };
+
+    const normalizeKeyframes = (data) => {
+        if (!data) return [];
+        if (Array.isArray(data)) {
+            return data.map(k => {
+                const time = +(k.time ?? k.t ?? 0);
+                if (!Number.isFinite(time)) return null;
+                const state = k.state ? k.state : (() => {
+                    const copy = { ...k };
+                    delete copy.time;
+                    delete copy.t;
+                    return copy;
+                })();
+                return state ? { time, state } : null;
+            }).filter(Boolean);
+        }
+        if (typeof data === 'object') {
+            return Object.entries(data).map(([time, state]) => {
+                const t = +time;
+                if (!Number.isFinite(t)) return null;
+                return state ? { time: t, state } : null;
+            }).filter(Boolean);
+        }
+        return [];
+    };
+
+    const normalizeTimelines = (anim) => {
+        const raw = anim?.timelines ?? anim?.tracks ?? [];
+        if (Array.isArray(raw)) {
+            return raw.map(track => {
+                const item = track.item || track.id || track.target || track.shape || track.name;
+                const keyframes = normalizeKeyframes(track.keyframes);
+                if (!item || !keyframes.length) return null;
+                keyframes.sort((a, b) => a.time - b.time);
+                return { item, keyframes };
+            }).filter(Boolean);
+        }
+        if (raw && typeof raw === 'object') {
+            return Object.entries(raw).map(([item, value]) => {
+                const keyframes = normalizeKeyframes(value);
+                if (!keyframes.length) return null;
+                keyframes.sort((a, b) => a.time - b.time);
+                return { item, keyframes };
+            }).filter(Boolean);
+        }
+        return [];
+    };
+
+    const findFrame = (frames, time) => {
+        return frames.find(k => Math.abs(k.time - time) < EPSILON) || null;
+    };
+
+    const applyImportedState = (items, animations) => {
+        state.animations = animations;
+        state.items = items;
+        state.currentAnimId = state.animations[0]?.id || null;
+        state.selected && state.selected.clear && state.selected.clear();
+        state.tl.previewing = false;
+        state.tl.previewBackup = null;
+        state.tl.sec = 0;
+        state.tl.playing = false;
+        api.refreshAnimSelect && api.refreshAnimSelect();
+        api.renderKeyframeList && api.renderKeyframeList();
+        api.refreshElemList && api.refreshElemList();
+        api.draw && api.draw();
+        api.rebuildTicks && api.rebuildTicks();
+        api.placeCursor && api.placeCursor();
+    };
+
     function exportPack(minimal = false) {
         const { w, h } = api.getCSSSize ? api.getCSSSize() : { w: canvas.width, h: canvas.height };
         const els = state.items.map(it => serializeItem(it, w, h, minimal));
@@ -24,6 +274,51 @@ function registerFileSystem(ctx) {
             size: { w, h },
             elements: els,
             animations: anims
+        };
+    }
+
+    function exportSummary() {
+        const { w, h } = api.getCSSSize ? api.getCSSSize() : { w: canvas.width, h: canvas.height };
+        const items = state.items
+            .map(it => simplifyItem(it, w, h))
+            .filter(Boolean);
+
+        const animations = state.animations.map(anim => {
+            const trackMap = new Map();
+            (anim.keyframes || []).forEach(kf => {
+                const time = +kf.t;
+                (kf.snapshot || []).forEach(item => {
+                    const frames = trackMap.get(item.id) || [];
+                    const simplified = simplifyItem(item, w, h);
+                    if (!simplified) return;
+                    const existing = frames.find(f => Math.abs(f.time - time) < EPSILON);
+                    if (existing) {
+                        existing.state = simplified;
+                    } else {
+                        frames.push({ time, state: simplified });
+                    }
+                    trackMap.set(item.id, frames);
+                });
+            });
+            const timelines = Array.from(trackMap.entries()).map(([item, frames]) => ({
+                item,
+                keyframes: frames
+                    .filter(f => f && typeof f.time === 'number')
+                    .sort((a, b) => a.time - b.time)
+            })).filter(tl => tl.keyframes.length);
+            return {
+                name: anim.name,
+                duration: anim.duration,
+                timelines
+            };
+        });
+
+        return {
+            type: 'LinePackSummary',
+            version: 2,
+            size: { w, h },
+            items,
+            animations
         };
     }
 
@@ -58,32 +353,73 @@ function registerFileSystem(ctx) {
     }
 
     function importPack(pack) {
-        if (!pack || pack.type !== 'LinePack') throw new Error('LinePack v2 معتبر نیست');
-        const size = pack.size || { w: canvas.width, h: canvas.height };
-        const den = (p) => ({ x: p.x * size.w, y: p.y * size.h });
+        if (!pack || typeof pack !== 'object') throw new Error('فایل معتبر نیست');
+        if (pack.type === 'LinePack') {
+            importFullPack(pack);
+            return;
+        }
+        if (pack.type === 'LinePackSummary') {
+            importSummaryPack(pack);
+            return;
+        }
+        throw new Error('نوع فایل پشتیبانی نمی‌شود');
+    }
 
-        state.animations = (pack.animations || []).map(a => ({
+    function importFullPack(pack) {
+        const size = pack.size || { w: canvas.width, h: canvas.height };
+        const animations = (pack.animations || []).map(a => ({
             id: rndId('anim'),
             name: a.name,
             duration: a.duration,
             keyframes: (a.keyframes || []).map(k => ({
                 t: k.t,
-                snapshot: (k.snapshot || []).map(el => deserializeItem(el, size))
+                snapshot: (k.snapshot || []).map(el => deserializeItem(el, size)).filter(Boolean)
             }))
         }));
+        const items = (pack.elements || []).map(el => deserializeItem(el, size)).filter(Boolean);
+        applyImportedState(items, animations);
+    }
 
-        state.items = (pack.elements || []).map(el => deserializeItem(el, size));
-        state.currentAnimId = state.animations[0]?.id || null;
-        state.tl.previewing = false;
-        state.tl.previewBackup = null;
-        state.tl.sec = 0;
-        state.tl.playing = false;
-        api.refreshAnimSelect && api.refreshAnimSelect();
-        api.renderKeyframeList && api.renderKeyframeList();
-        api.refreshElemList && api.refreshElemList();
-        api.draw && api.draw();
-        api.rebuildTicks && api.rebuildTicks();
-        api.placeCursor && api.placeCursor();
+    function importSummaryPack(pack) {
+        const size = pack.size || { w: canvas.width, h: canvas.height };
+        const items = (pack.items || []).map(entry => inflateItem(entry, size)).filter(Boolean);
+        const animations = (pack.animations || []).map(anim => {
+            const timelines = normalizeTimelines(anim);
+            if (!timelines.length) {
+                return {
+                    id: rndId('anim'),
+                    name: anim.name || 'Animation',
+                    duration: +(anim.duration || 5),
+                    keyframes: []
+                };
+            }
+            const timeSet = new Set();
+            timelines.forEach(track => {
+                track.keyframes.forEach(kf => timeSet.add(+kf.time || 0));
+            });
+            const times = Array.from(timeSet).sort((a, b) => a - b);
+            const keyframes = times.map(time => {
+                const snapshot = [];
+                timelines.forEach(track => {
+                    const frame = findFrame(track.keyframes, time);
+                    if (!frame) return;
+                    const stateData = { ...frame.state };
+                    stateData.id = stateData.id || track.item;
+                    stateData.type = stateData.type || stateData.kind;
+                    stateData.kind = stateData.kind || stateData.type;
+                    const item = inflateItem(stateData, size);
+                    if (item) snapshot.push(item);
+                });
+                return { t: time, snapshot };
+            }).filter(kf => kf.snapshot.length);
+            return {
+                id: rndId('anim'),
+                name: anim.name || 'Animation',
+                duration: +(anim.duration || 5),
+                keyframes
+            };
+        });
+        applyImportedState(items, animations);
     }
 
     function deserializeItem(el, size) {
@@ -130,8 +466,8 @@ function registerFileSystem(ctx) {
     }
 
     ui.saveJSON.addEventListener('click', () => {
-        const data = exportPack(false);
-        downloadBlob(JSON.stringify(data, null, 2), 'drawing.linepack.json');
+        const data = exportSummary();
+        downloadBlob(JSON.stringify(data, null, 2), 'drawing.simple.json');
     });
 
     ui.saveJSONMin.addEventListener('click', () => {
@@ -170,7 +506,7 @@ function registerFileSystem(ctx) {
         }
     });
 
-    const exposed = { exportPack, importPack, downloadBlob };
+    const exposed = { exportPack, importPack, downloadBlob, exportSummary };
     Object.assign(api, exposed);
     return { exposed };
 }


### PR DESCRIPTION
## Summary
- add helpers that normalize points and segments so export summary items use compact geometry arrays
- rewrite summary exporter to emit per-item timelines and reduce redundant data while keeping ids, colors, paths, and fills
- update importer to accept the new summary structure, rebuild keyframes from per-item tracks, and clear stale selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690495c9c8748321a63d6bed1f06b9ec